### PR TITLE
Add basic SwiftUI Xcode project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Xcode
+.DS_Store
+build/
+DerivedData/
+*.xcuserstate
+*.xcworkspace
+*.xcodeproj/project.xcworkspace/
+*.xcodeproj/xcuserdata/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # CannabisApp
+
+This repository now contains a simple SwiftUI iOS project.
+
+## Running the iOS app
+
+1. Open **iOS/CannabisApp.xcodeproj** in Xcode.
+2. Select an iOS simulator or a connected device.
+3. Press the **Run** button or use `Cmd+R` to build and launch the app.
+
+The app shows a basic `ContentView` with a greeting message.

--- a/iOS/CannabisApp.xcodeproj/project.pbxproj
+++ b/iOS/CannabisApp.xcodeproj/project.pbxproj
@@ -1,0 +1,174 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  classes = {};
+  objectVersion = 55;
+  objects = {
+
+/* Begin PBXBuildFile section */
+    000000000000000000000006 /* CannabisAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000004 /* CannabisAppApp.swift */; };
+    000000000000000000000008 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000005 /* ContentView.swift */; };
+    00000000000000000000000A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000009 /* Assets.xcassets */; };
+    00000000000000000000000C /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000000B /* Info.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+    000000000000000000000004 /* CannabisAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CannabisAppApp.swift; sourceTree = "<group>"; };
+    000000000000000000000005 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+    000000000000000000000009 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+    00000000000000000000000B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+    00000000000000000000000D /* CannabisApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = CannabisApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+    000000000000000000000003 = {
+        isa = PBXGroup;
+        children = (
+            000000000000000000000004 /* CannabisAppApp.swift */,
+            000000000000000000000005 /* ContentView.swift */,
+            000000000000000000000009 /* Assets.xcassets */,
+            00000000000000000000000B /* Info.plist */,
+        );
+        path = "";
+        sourceTree = "<group>";
+    };
+    000000000000000000000013 = {
+        isa = PBXGroup;
+        children = (
+            00000000000000000000000D /* CannabisApp.app */,
+        );
+        name = Products;
+        sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+    000000000000000000000002 /* CannabisApp */ = {
+        isa = PBXNativeTarget;
+        buildConfigurationList = 000000000000000000000011 /* Build configuration list for PBXNativeTarget "CannabisApp" */;
+        buildPhases = (
+            00000000000000000000000E /* Sources */,
+            00000000000000000000000F /* Resources */,
+        );
+        buildRules = (
+        );
+        dependencies = (
+        );
+        name = CannabisApp;
+        productName = CannabisApp;
+        productReference = 00000000000000000000000D /* CannabisApp.app */;
+        productType = "com.apple.product-type.application";
+    };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+    000000000000000000000001 /* Project object */ = {
+        isa = PBXProject;
+        attributes = {
+            LastUpgradeCheck = 1500;
+            ORGANIZATIONNAME = "Codex";
+        };
+        buildConfigurationList = 000000000000000000000010 /* Build configuration list for PBXProject "CannabisApp" */;
+        compatibilityVersion = "Xcode 15.0";
+        developmentRegion = en;
+        hasScannedForEncodings = 0;
+        knownRegions = (
+            en,
+        );
+        mainGroup = 000000000000000000000003;
+        productRefGroup = 000000000000000000000013;
+        projectDirPath = "";
+        projectRoot = "";
+        targets = (
+            000000000000000000000002 /* CannabisApp */,
+        );
+    };
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+    00000000000000000000000E /* Sources */ = {
+        isa = PBXSourcesBuildPhase;
+        buildActionMask = 2147483647;
+        files = (
+            000000000000000000000006 /* CannabisAppApp.swift in Sources */,
+            000000000000000000000008 /* ContentView.swift in Sources */,
+        );
+        runOnlyForDeploymentPostprocessing = 0;
+    };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXResourcesBuildPhase section */
+    00000000000000000000000F /* Resources */ = {
+        isa = PBXResourcesBuildPhase;
+        buildActionMask = 2147483647;
+        files = (
+            00000000000000000000000A /* Assets.xcassets in Resources */,
+            00000000000000000000000C /* Info.plist in Resources */,
+        );
+        runOnlyForDeploymentPostprocessing = 0;
+    };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+    000000000000000000000012 /* Debug */ = {
+        isa = XCBuildConfiguration;
+        buildSettings = {
+            PRODUCT_NAME = "$(TARGET_NAME)";
+        };
+        name = Debug;
+    };
+    000000000000000000000013 /* Release */ = {
+        isa = XCBuildConfiguration;
+        buildSettings = {
+            PRODUCT_NAME = "$(TARGET_NAME)";
+        };
+        name = Release;
+    };
+    000000000000000000000014 /* Debug */ = {
+        isa = XCBuildConfiguration;
+        buildSettings = {
+            INFOPLIST_FILE = "Info.plist";
+            PRODUCT_BUNDLE_IDENTIFIER = "com.example.cannabisapp";
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SWIFT_VERSION = 5.9;
+            TARGETED_DEVICE_FAMILY = "1";
+        };
+        name = Debug;
+    };
+    000000000000000000000015 /* Release */ = {
+        isa = XCBuildConfiguration;
+        buildSettings = {
+            INFOPLIST_FILE = "Info.plist";
+            PRODUCT_BUNDLE_IDENTIFIER = "com.example.cannabisapp";
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SWIFT_VERSION = 5.9;
+            TARGETED_DEVICE_FAMILY = "1";
+        };
+        name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    000000000000000000000010 /* Build configuration list for PBXProject "CannabisApp" */ = {
+        isa = XCConfigurationList;
+        buildConfigurations = (
+            000000000000000000000012 /* Debug */,
+            000000000000000000000013 /* Release */,
+        );
+        defaultConfigurationIsVisible = 0;
+        defaultConfigurationName = Release;
+    };
+    000000000000000000000011 /* Build configuration list for PBXNativeTarget "CannabisApp" */ = {
+        isa = XCConfigurationList;
+        buildConfigurations = (
+            000000000000000000000014 /* Debug */,
+            000000000000000000000015 /* Release */,
+        );
+        defaultConfigurationIsVisible = 0;
+        defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 000000000000000000000001 /* Project object */;
+}

--- a/iOS/CannabisApp/Assets.xcassets/Contents.json
+++ b/iOS/CannabisApp/Assets.xcassets/Contents.json
@@ -1,0 +1,8 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "properties" : {
+  }
+}

--- a/iOS/CannabisApp/CannabisAppApp.swift
+++ b/iOS/CannabisApp/CannabisAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CannabisAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/iOS/CannabisApp/ContentView.swift
+++ b/iOS/CannabisApp/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, CannabisApp!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/iOS/CannabisApp/Info.plist
+++ b/iOS/CannabisApp/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>CannabisApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.cannabisapp</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a simple SwiftUI project under `iOS` with `CannabisApp.xcodeproj`
- ignore Xcode build output with `.gitignore`
- document how to open and run the project in Xcode

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685be69627dc8332af94127423e443a1