### PR TITLE
Improve README with build & contribution info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # CannabisApp
+
+## Overview
+CannabisApp is a simple prototype for a cannabis comparison application. The repository currently contains a basic HTML page which can be expanded into a full mobile app.
+
+## Building the iOS version
+To build an iOS app using this codebase you can wrap the project with a hybrid framework (for example Cordova) and compile it with Xcode:
+
+1. Install **Xcode** from the Mac App Store.
+2. Install Cordova globally with `npm install -g cordova` or use your preferred framework.
+3. Run `cordova platform add ios` inside this repository to create the iOS project.
+4. Open `platforms/ios/*.xcodeproj` in Xcode.
+5. Build and run the application in the simulator or on a device.
+
+## Contributing
+We welcome contributions! Fork this repository, create a feature branch, commit your changes and open a pull request. Please follow standard GitHub workflow and keep your commits concise.
+
+## License
+This project is distributed under the MIT License. See the `LICENSE` file for details.


### PR DESCRIPTION
## Summary
- replace empty README with a project overview
- add steps to build the iOS version using Xcode
- document how to contribute and mention the MIT license

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be69b910c83328b5f66185baf8100