### PR TITLE
Add main menu with navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,20 @@ document.getElementById('search-input').addEventListener('input', e => {
   renderProducts(filtered);
 });
 
+function setupNavigation() {
+  const buttons = document.querySelectorAll('#main-menu button');
+  const sections = document.querySelectorAll('.content-section');
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      sections.forEach(sec => {
+        sec.hidden = sec.id !== btn.dataset.target;
+      });
+    });
+  });
+}
+
 window.addEventListener('load', () => {
   renderProducts(products);
+  setupNavigation();
 });

--- a/index.html
+++ b/index.html
@@ -6,11 +6,53 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <h1>Willkommen zur Cannabis Vergleichs-App</h1>
-    <div id="search-container">
-      <input type="text" id="search-input" placeholder="Sorte suchen..." />
-    </div>
-    <div id="product-list"></div>
+    <header>
+      <h1>CannabisApp</h1>
+      <nav id="main-menu">
+        <button data-target="compare-section">Vergleich</button>
+        <button data-target="safeuse-section">Safe-Use</button>
+        <button data-target="map-section">Karte</button>
+        <button data-target="news-section">Neuigkeiten</button>
+      </nav>
+    </header>
+
+    <main>
+      <section id="compare-section" class="content-section">
+        <h2>Sorten vergleichen</h2>
+        <div id="search-container">
+          <input type="text" id="search-input" placeholder="Sorte suchen..." />
+        </div>
+        <div id="product-list"></div>
+      </section>
+
+      <section id="safeuse-section" class="content-section" hidden>
+        <h2>Safe-Use Regeln</h2>
+        <p>
+          Informiere dich stets über die aktuelle Gesetzeslage und konsumiere nur,
+          wenn es für dich legal ist. Beachte verantwortungsvolle Dosierung,
+          konsumiere nicht am Straßenverkehr und halte Pausen ein. Bei Fragen
+          wende dich an medizinisches Fachpersonal.
+        </p>
+      </section>
+
+      <section id="map-section" class="content-section" hidden>
+        <h2>Konsumkarte</h2>
+        <p>Die Karte dient nur als Orientierung. Prüfe lokale Gesetze.</p>
+        <iframe
+          title="OpenStreetMap"
+          src="https://www.openstreetmap.org/export/embed.html"
+          style="width: 100%; height: 300px; border: 1px solid #ccc;"
+        ></iframe>
+      </section>
+
+      <section id="news-section" class="content-section" hidden>
+        <h2>Neuigkeiten</h2>
+        <ul>
+          <li><a href="https://www.cannabis-med.org/" target="_blank">Aktuelle Meldungen</a></li>
+          <li><a href="https://hanfverband.de/nachrichten" target="_blank">Pressemitteilungen</a></li>
+        </ul>
+      </section>
+    </main>
 
     <script src="app.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,36 @@
 body {
   font-family: Arial, sans-serif;
   margin: 0;
-  padding: 20px;
+  padding: 0;
   background-color: #f5f5f5;
+}
+
+header {
+  background-color: #2c3e50;
+  color: #fff;
+  padding: 10px 20px;
+}
+
+#main-menu {
+  margin-top: 10px;
+}
+
+#main-menu button {
+  margin-right: 10px;
+  padding: 8px 16px;
+  border: none;
+  background-color: #3498db;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#main-menu button:hover {
+  background-color: #2980b9;
+}
+
+main {
+  padding: 20px;
 }
 
 #search-container {


### PR DESCRIPTION
## Summary
- add navigation menu with sections for Vergleich, Safe-Use, Karte and News
- implement section switching logic in JavaScript
- style header and navigation

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_685c06e5250c8332b947ef84975580e1