### PR TITLE
Add main menu page with navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,15 +54,26 @@ document.getElementById('search-input').addEventListener('input', e => {
   renderProducts(filtered);
 });
 
-function setupNavigation() {
-  const buttons = document.querySelectorAll('#main-menu button');
+function showSection(id) {
   const sections = document.querySelectorAll('.content-section');
+  sections.forEach(sec => {
+    sec.hidden = sec.id !== id;
+  });
+}
 
-  buttons.forEach(btn => {
+function setupNavigation() {
+  const menuButtons = document.querySelectorAll('#main-menu button');
+  const backButtons = document.querySelectorAll('.back-button');
+
+  menuButtons.forEach(btn => {
     btn.addEventListener('click', () => {
-      sections.forEach(sec => {
-        sec.hidden = sec.id !== btn.dataset.target;
-      });
+      showSection(btn.dataset.target);
+    });
+  });
+
+  backButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      showSection('menu-section');
     });
   });
 }
@@ -70,4 +81,5 @@ function setupNavigation() {
 window.addEventListener('load', () => {
   renderProducts(products);
   setupNavigation();
+  showSection('menu-section');
 });

--- a/index.html
+++ b/index.html
@@ -8,21 +8,26 @@
   <body>
     <header>
       <h1>CannabisApp</h1>
-      <nav id="main-menu">
-        <button data-target="compare-section">Vergleich</button>
-        <button data-target="safeuse-section">Safe-Use</button>
-        <button data-target="map-section">Karte</button>
-        <button data-target="news-section">Neuigkeiten</button>
-      </nav>
     </header>
 
     <main>
-      <section id="compare-section" class="content-section">
+      <section id="menu-section" class="content-section">
+        <h2>Hauptmenü</h2>
+        <div id="main-menu">
+          <button data-target="compare-section">Vergleich</button>
+          <button data-target="safeuse-section">Safe-Use</button>
+          <button data-target="map-section">Karte</button>
+          <button data-target="news-section">Neuigkeiten</button>
+        </div>
+      </section>
+
+      <section id="compare-section" class="content-section" hidden>
         <h2>Sorten vergleichen</h2>
         <div id="search-container">
           <input type="text" id="search-input" placeholder="Sorte suchen..." />
         </div>
         <div id="product-list"></div>
+        <button class="back-button">Zurück zum Hauptmenü</button>
       </section>
 
       <section id="safeuse-section" class="content-section" hidden>
@@ -33,6 +38,7 @@
           konsumiere nicht am Straßenverkehr und halte Pausen ein. Bei Fragen
           wende dich an medizinisches Fachpersonal.
         </p>
+        <button class="back-button">Zurück zum Hauptmenü</button>
       </section>
 
       <section id="map-section" class="content-section" hidden>
@@ -43,6 +49,7 @@
           src="https://www.openstreetmap.org/export/embed.html"
           style="width: 100%; height: 300px; border: 1px solid #ccc;"
         ></iframe>
+        <button class="back-button">Zurück zum Hauptmenü</button>
       </section>
 
       <section id="news-section" class="content-section" hidden>
@@ -51,6 +58,7 @@
           <li><a href="https://www.cannabis-med.org/" target="_blank">Aktuelle Meldungen</a></li>
           <li><a href="https://hanfverband.de/nachrichten" target="_blank">Pressemitteilungen</a></li>
         </ul>
+        <button class="back-button">Zurück zum Hauptmenü</button>
       </section>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -51,3 +51,17 @@ main {
   padding: 10px;
   margin-bottom: 10px;
 }
+
+.back-button {
+  margin-top: 20px;
+  padding: 8px 16px;
+  border: none;
+  background-color: #95a5a6;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.back-button:hover {
+  background-color: #7f8c8d;
+}


### PR DESCRIPTION
## Summary
- create a dedicated `menu-section` with navigation buttons
- add `back-button` on each section
- update JS to handle navigation through main menu
- style the new back button

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685c51067eac83329828c1c46f20c783