### PR TITLE
Implement main menu and expand strain list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 Dieses Projekt stellt eine einfache Vergleichs-App für Cannabisprodukte bereit. 
 Ziel ist es, unterschiedliche Sorten samt Eigenschaften wie THC- und CBD-Gehalt
-zu vergleichen. Jede Sorte enthält nun auch eine kurze Beschreibung ihres
+zu vergleichen. Jede Sorte enthält eine kurze Beschreibung ihres
 typischen Einsatzzwecks. Eine Suchfunktion ermöglicht das Filtern nach Namen.
+Beim Start erscheint nun ein Hauptmenü, über das die einzelnen Bereiche
+aufgerufen werden können.
 
 ## Lokale Nutzung
 
@@ -12,8 +14,8 @@ typischen Einsatzzwecks. Eine Suchfunktion ermöglicht das Filtern nach Namen.
    Entwicklungsserver (z. B. `npx serve` oder die Live-Server-Erweiterung in VS Code)
    verwendet werden.
 
-Beim Laden erscheint eine Liste einiger Beispielsorten. Über das Suchfeld lassen
-sich die Einträge filtern.
+Im Bereich "Vergleich" wird eine Liste verschiedener Sorten angezeigt. Über das
+Suchfeld lassen sich die Einträge filtern.
 
 ## Lizenz
 

--- a/app.js
+++ b/app.js
@@ -1,42 +1,47 @@
 const products = [
   {
-    name: 'Sorte A',
-    thc: 20,
-    cbd: 1,
-    description: 'Klassische Hybridsorte mit ausgewogenem Wirkungsspektrum.'
-  },
-  {
-    name: 'Sorte B',
-    thc: 15,
-    cbd: 5,
-    description: 'Milderes Produkt, wird oft zur leichten Entspannung genutzt.'
-  },
-  {
-    name: 'Sorte C',
-    thc: 10,
-    cbd: 12,
-    description: 'CBD-reich, beliebt zur Linderung von Entzündungen.'
-  },
-  {
     name: 'Amnesia Haze',
     thc: 22,
     cbd: 1,
-    description: 'Energetische Sorte, häufig gegen Müdigkeit eingesetzt.'
+    description: 'Energetische Sorte, h\u00e4ufig gegen M\u00fcdigkeit eingesetzt.'
   },
   {
     name: 'Northern Lights',
     thc: 18,
     cbd: 2,
-    description: 'Bekannt für beruhigende Wirkung, ideal zum Entspannen am Abend.'
+    description: 'Bekannt f\u00fcr beruhigende Wirkung, ideal zum Entspannen am Abend.'
   },
   {
     name: "Charlotte's Web",
     thc: 1,
     cbd: 15,
-    description: 'Speziell für medizinische Zwecke gezüchtet, z. B. bei Epilepsie.'
+    description: 'Speziell f\u00fcr medizinische Zwecke gez\u00fcchtet, z. B. bei Epilepsie.'
+  },
+  {
+    name: 'Blue Dream',
+    thc: 17,
+    cbd: 2,
+    description: 'Ber\u00fchmte kalifornische Sorte mit ausgeglichenem High.'
+  },
+  {
+    name: 'Super Lemon Haze',
+    thc: 20,
+    cbd: 1,
+    description: 'Fruchtig-zitroniges Aroma und anregende Wirkung.'
+  },
+  {
+    name: 'White Widow',
+    thc: 19,
+    cbd: 1,
+    description: 'Klassiker aus den 90ern, sorgt f\u00fcr ausgeglichene Effekte.'
+  },
+  {
+    name: 'Purple Kush',
+    thc: 21,
+    cbd: 0,
+    description: 'Reine Indica-Sorte, bekannt f\u00fcr tief entspannende Wirkung.'
   }
 ];
-
 function renderProducts(list) {
   const container = document.getElementById('product-list');
   container.innerHTML = '';
@@ -55,7 +60,7 @@ document.getElementById('search-input').addEventListener('input', e => {
 });
 
 function setupNavigation() {
-  const buttons = document.querySelectorAll('#main-menu button');
+  const buttons = document.querySelectorAll('button[data-target]');
   const sections = document.querySelectorAll('.content-section');
 
   buttons.forEach(btn => {

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <header>
       <h1>CannabisApp</h1>
       <nav id="main-menu">
+        <button data-target="home-section">Start</button>
         <button data-target="compare-section">Vergleich</button>
         <button data-target="safeuse-section">Safe-Use</button>
         <button data-target="map-section">Karte</button>
@@ -18,7 +19,17 @@
     </header>
 
     <main>
-      <section id="compare-section" class="content-section">
+      <section id="home-section" class="content-section">
+        <h2>Willkommen</h2>
+        <p>Wähle eine Kategorie, um fortzufahren:</p>
+        <ul>
+          <li><button data-target="compare-section">Sorten vergleichen</button></li>
+          <li><button data-target="safeuse-section">Safe-Use</button></li>
+          <li><button data-target="map-section">Karte</button></li>
+          <li><button data-target="news-section">Neuigkeiten</button></li>
+        </ul>
+      </section>
+      <section id="compare-section" class="content-section" hidden>
         <h2>Sorten vergleichen</h2>
         <div id="search-container">
           <input type="text" id="search-input" placeholder="Sorte suchen..." />


### PR DESCRIPTION
## Summary
- create a start page with navigation links
- hide compare section by default and add Home button in nav
- remove placeholder strains and add real ones
- update navigation handler for new menu buttons
- adjust README instructions for new menu

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685c585d4f58833292f961c20f3e82f7