### PR TITLE
Enhance main menu tile size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -83,10 +83,22 @@ main {
   list-style: none;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(4cm, 1fr));
   gap: 10px;
 }
 
 #home-section li {
   margin-bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#home-section li button {
+  width: 4cm;
+  height: 4cm;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- ensure main menu uses a grid of 4cm square tiles
- center button text within these tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ea2a8e4f883328116453d1f651d71