### PR TITLE
Setup GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,35 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ Responsive-Design.
 Im Bereich "Vergleich" wird eine Liste verschiedener Sorten angezeigt. Über das
 Suchfeld lassen sich die Einträge filtern.
 
+## GitHub Pages
+
+Um die App ohne erneutes Herunterladen zu verwenden, kann sie auf GitHub Pages
+bereitgestellt werden. Das Repository enthält dafür einen Workflow unter
+`.github/workflows/gh-pages.yml`.
+
+1. Repository auf GitHub erstellen und die Dateien hochladen oder per `git push`
+   übertragen.
+2. In den Repository-Einstellungen unter **Pages** als Quelle **GitHub Actions**
+   auswählen.
+3. Bei jedem Push auf den Branch `main` veröffentlicht der Workflow die App und
+   zeigt die zugehörige URL im "Pages"-Bereich an.
+
 ## Lizenz
 
 Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).


### PR DESCRIPTION
## Summary
- automate GitHub Pages deployment via GitHub Actions
- document how to enable Pages and publish the app

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ea83a91bc8332a08a7d82671cc426