### PR TITLE
Implement mobile homescreen links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Die Oberfläche nutzt ein modernes Layout mit Karten und Responsive-Design. Im B
 ## Lokale Nutzung
 
 1. Repository klonen oder herunterladen.
-2. `index.html` in einem Browser öffnen. Alternativ kann ein einfacher Entwicklungsserver (z. B. `npx serve` oder die Live-Server-Erweiterung in VS Code) verwendet werden.
+2. `homescreen.html` im Browser öffnen. Diese mobile Startseite verlinkt direkt zu den Bereichen der App in `index.html`. Alternativ kann ein einfacher Entwicklungsserver (z. B. `npx serve` oder die Live-Server-Erweiterung in VS Code) verwendet werden.
 3. Die Liste der Produkte befindet sich in der Datei `products.json` und wird von `app.js` per `fetch` geladen. Stelle sicher, dass diese Datei neben der HTML-Seite verfügbar ist.
 4. **Hinweis:** `app.js` wird durch die HTML-Seite eingebunden und ist nicht für die Ausführung mit Node gedacht. Bei einem Versuch mit `node app.js` erscheint typischerweise der Fehler `ReferenceError: document is not defined`.
 5. Optional können mit `npm test` einfache Tests ausgeführt werden. Derzeit wird lediglich der Text `no tests` ausgegeben.

--- a/app.js
+++ b/app.js
@@ -111,16 +111,22 @@ searchInput.addEventListener('input', applyFilters);
 thcInput.addEventListener('input', applyFilters);
 cbdInput.addEventListener('input', applyFilters);
 
-function setupNavigation() {
+function showSection(id) {
   const buttons = document.querySelectorAll('button[data-target]');
   const sections = document.querySelectorAll('.content-section');
+  sections.forEach(sec => {
+    sec.hidden = sec.id !== id;
+  });
+  buttons.forEach(b => {
+    b.classList.toggle('active', b.dataset.target === id);
+  });
+}
 
+function setupNavigation() {
+  const buttons = document.querySelectorAll('button[data-target]');
   buttons.forEach(btn => {
     btn.addEventListener('click', () => {
-      sections.forEach(sec => {
-        sec.hidden = sec.id !== btn.dataset.target;
-      });
-      buttons.forEach(b => b.classList.toggle('active', b === btn));
+      showSection(btn.dataset.target);
     });
   });
 }
@@ -131,8 +137,7 @@ window.addEventListener('load', async () => {
   renderProducts(products);
   setupNavigation();
   initMap();
-  const homeButton = document.querySelector('button[data-target="home-section"]');
-  if (homeButton) {
-    homeButton.classList.add('active');
-  }
+  const params = new URLSearchParams(window.location.search);
+  const target = params.get('section') || 'home-section';
+  showSection(target);
 });

--- a/homescreen.html
+++ b/homescreen.html
@@ -23,16 +23,16 @@
 
     <!-- Navigationsbuttons -->
     <div class="grid grid-cols-2 gap-4 mb-8">
-      <a href="#" class="flex flex-col items-center justify-center bg-[#3B82F6] text-white rounded-full h-24">
+      <a href="index.html?section=compare-section" class="flex flex-col items-center justify-center bg-[#3B82F6] text-white rounded-full h-24">
         Sorten vergleichen
       </a>
-      <a href="#" class="flex flex-col items-center justify-center bg-[#047857] text-white rounded-full h-24">
+      <a href="index.html?section=safeuse-section" class="flex flex-col items-center justify-center bg-[#047857] text-white rounded-full h-24">
         Safe-Use
       </a>
-      <a href="#" class="flex flex-col items-center justify-center bg-[#3B82F6] text-white rounded-full h-24">
+      <a href="index.html?section=map-section" class="flex flex-col items-center justify-center bg-[#3B82F6] text-white rounded-full h-24">
         Karte
       </a>
-      <a href="#" class="flex flex-col items-center justify-center bg-[#047857] text-white rounded-full h-24">
+      <a href="index.html?section=news-section" class="flex flex-col items-center justify-center bg-[#047857] text-white rounded-full h-24">
         Neuigkeiten
       </a>
     </div>


### PR DESCRIPTION
## Summary
- wire up homescreen navigation buttons to `index.html`
- add utility to open sections based on query parameter
- document new `homescreen.html` entrypoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe9aa8a748332bf446326f00f3685