### PR TITLE
Add inline SVG for hero illustration

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,20 @@
         </div>
 
         <!-- Hero-Illustration -->
-        <img src="https://via.placeholder.com/400x200.png?text=Illustration" alt="Person mit Cannabispflanze" class="rounded-xl w-full mb-6" />
+        <svg class="rounded-xl w-full mb-6" viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg" aria-label="Person mit Cannabispflanze">
+          <!-- Person -->
+          <circle cx="70" cy="60" r="20" fill="#8B5CF6" />
+          <rect x="60" y="80" width="20" height="60" fill="#8B5CF6" />
+          <line x1="60" y1="100" x2="40" y2="140" stroke="#8B5CF6" stroke-width="5" />
+          <line x1="80" y1="100" x2="100" y2="140" stroke="#8B5CF6" stroke-width="5" />
+          <line x1="60" y1="140" x2="50" y2="180" stroke="#8B5CF6" stroke-width="5" />
+          <line x1="80" y1="140" x2="90" y2="180" stroke="#8B5CF6" stroke-width="5" />
+          <!-- Plant -->
+          <rect x="160" y="120" width="10" height="40" fill="#047857" />
+          <circle cx="165" cy="110" r="15" fill="#047857" />
+          <circle cx="150" cy="125" r="12" fill="#047857" />
+          <circle cx="180" cy="125" r="12" fill="#047857" />
+        </svg>
 
         <!-- Willkommen-Text -->
         <h2 class="text-3xl text-emerald-700 mb-2">Willkommen</h2>


### PR DESCRIPTION
## Summary
- replace placeholder hero image with a simple inline SVG depicting a person with a cannabis plant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628d993978833293bf33e3f88cd7ad