### PR TITLE
Update strains and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
         <h1 class="text-2xl font-bold">CannabisApp</h1>
         <nav id="main-menu" class="mt-3 flex flex-wrap justify-center gap-2">
           <button data-target="home-section" class="px-4 py-2 rounded-full shadow-md bg-blue-500 text-white transition duration-200 hover:bg-blue-600">Start</button>
-          <button data-target="compare-section" class="px-4 py-2 rounded-full shadow-md bg-blue-500 text-white transition duration-200 hover:bg-blue-600">Vergleich</button>
           <button data-target="safeuse-section" class="px-4 py-2 rounded-full shadow-md bg-blue-500 text-white transition duration-200 hover:bg-blue-600">Safe-Use</button>
           <button data-target="map-section" class="px-4 py-2 rounded-full shadow-md bg-blue-500 text-white transition duration-200 hover:bg-blue-600">Karte</button>
           <button data-target="news-section" class="px-4 py-2 rounded-full shadow-md bg-blue-500 text-white transition duration-200 hover:bg-blue-600">Neuigkeiten</button>

--- a/strains.html
+++ b/strains.html
@@ -32,6 +32,36 @@ const strains = [
     effects: ["😴", "🧘"],
     rating: 4.8,
     description: "Beruhigend und entspannend"
+  },
+  {
+    name: "Gelato",
+    type: "Hybrid",
+    thc: 20,
+    cbd: 1,
+    image: "https://leafly-cms-production.imgix.net/wp-content/uploads/2020/09/30122136/Strain-Gelato.jpg",
+    effects: ["😂", "🧘"],
+    rating: 4.7,
+    description: "Entspannend und euphorisch"
+  },
+  {
+    name: "Blue Dream",
+    type: "Sativa",
+    thc: 19,
+    cbd: 2,
+    image: "https://weedmaps.com/learn/strains/blue-dream/blue-dream1.jpg",
+    effects: ["🌞", "😂"],
+    rating: 4.6,
+    description: "Belebend und kreativ"
+  },
+  {
+    name: "OG Kush",
+    type: "Indica",
+    thc: 21,
+    cbd: 1,
+    image: "https://weedmaps.com/learn/strains/og-kush/ogkush1.jpg",
+    effects: ["😴", "🧘"],
+    rating: 4.8,
+    description: "Stark entspannend"
   }
 ];
 


### PR DESCRIPTION
## Summary
- remove `Vergleich` button from the navigation in `index.html`
- extend the strains list in `strains.html` with Gelato, Blue Dream and OG Kush

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68640605c5fc83328348706c99d4af59