### PR TITLE
Add simple mobile homescreen

### DIFF
--- a/homescreen.html
+++ b/homescreen.html
@@ -4,48 +4,89 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
 </head>
-<body class="bg-white font-sans font-semibold text-gray-800 text-lg">
-  <div class="max-w-md mx-auto px-4 py-6">
-    <!-- Suchleiste -->
-    <div class="relative mb-6">
-      <input type="text" placeholder="Suchen..."
-             class="w-full pl-10 pr-4 py-2 border rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
-      <svg class="w-5 h-5 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-        <path fill-rule="evenodd" d="M12.9 14.32a8 8 0 111.414-1.414l4.386 4.386a1 1 0 01-1.414 1.414l-4.386-4.386zM14 8a6 6 0 11-12 0 6 6 0 0112 0z" clip-rule="evenodd"/>
-      </svg>
+<body class="bg-gray-100 text-gray-800 font-sans text-lg font-semibold tracking-wide flex flex-col min-h-screen">
+  <header class="bg-emerald-700 text-white py-4">
+    <div class="max-w-md mx-auto text-center">
+      <h1 class="text-2xl font-bold">CannabisApp</h1>
     </div>
+  </header>
 
-    <!-- Hero-Illustration -->
-    <img src="https://via.placeholder.com/400x200.png?text=Illustration" alt="Person mit Cannabispflanze" class="rounded-xl w-full mb-6">
-
-    <!-- Willkommen-Text -->
-    <h1 class="text-3xl text-emerald-700 mb-2">Willkommen</h1>
-    <p class="mb-6">Wähle eine Kategorie, um fortzufahren:</p>
-
-    <!-- Navigationsbuttons -->
-    <div class="grid grid-cols-2 gap-4 mb-8">
-      <a href="index.html?section=compare-section" class="bg-sky-500 hover:bg-sky-600 rounded-xl text-white py-4 flex items-center justify-center text-center">Sorten vergleichen</a>
-      <a href="index.html?section=safeuse-section" class="bg-sky-500 hover:bg-sky-600 rounded-xl text-white py-4 flex items-center justify-center text-center">Safe-Use</a>
-      <a href="index.html?section=map-section" class="bg-sky-500 hover:bg-sky-600 rounded-xl text-white py-4 flex items-center justify-center text-center">Karte</a>
-      <a href="index.html?section=news-section" class="bg-sky-500 hover:bg-sky-600 rounded-xl text-white py-4 flex items-center justify-center text-center">Neuigkeiten</a>
-    </div>
-
-    <!-- News-Bereich -->
+  <main class="flex-1 max-w-md mx-auto p-4 pb-24">
     <section>
-      <h2 class="text-xl text-emerald-700 mb-4">News</h2>
-      <div class="flex items-start bg-gray-50 p-4 rounded-xl">
-        <div class="bg-gray-200 h-24 w-24 rounded mr-4"></div>
+      <h2 class="text-xl text-emerald-700 mb-4">Heute für dich</h2>
+
+      <!-- Strain-Tipp -->
+      <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+        <img src="https://via.placeholder.com/400x200.png?text=Cheese" alt="Cheese" class="w-full h-40 object-cover">
+        <div class="p-4">
+          <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+          <h3 class="mt-2 text-lg font-bold">Cheese</h3>
+          <p class="mt-1">Kreativität steigernde Wirkung</p>
+          <a href="#" class="text-blue-600 underline mt-2 inline-block">Mehr anzeigen</a>
+        </div>
+      </div>
+
+      <!-- Safer-Use-Tipp -->
+      <div class="bg-white rounded-xl shadow mb-4 p-4 flex items-start">
+        <div class="text-4xl mr-3">🛡️</div>
         <div class="flex-1">
-          <h3 class="font-semibold mb-2">News headline</h3>
-          <div class="space-y-2">
-            <div class="bg-gray-100 h-3 rounded w-2/3"></div>
-            <div class="bg-gray-100 h-3 rounded w-1/2"></div>
-          </div>
+          <h3 class="font-bold">Safer-Use-Tipp</h3>
+          <p class="mt-1">Starte mit einer niedrigen Dosis</p>
+          <a href="#" class="text-blue-600 underline">Mehr anzeigen</a>
+        </div>
+      </div>
+
+      <!-- News -->
+      <div class="bg-white rounded-xl shadow p-4 flex items-start">
+        <div class="text-4xl mr-3">📰</div>
+        <div class="flex-1">
+          <h3 class="font-bold">News</h3>
+          <p class="mt-1">Neues Gesetz zur Legalisierung beschlossen</p>
+          <a href="#" class="text-blue-600 underline">Mehr anzeigen</a>
         </div>
       </div>
     </section>
-  </div>
+  </main>
+
+  <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg">
+    <ul class="flex justify-around py-2 text-sm">
+      <li class="flex flex-col items-center">
+        <span class="text-xl">🌿</span>
+        <span>Strains</span>
+      </li>
+      <li class="flex flex-col items-center">
+        <span class="text-xl">🔍</span>
+        <span>Finder</span>
+      </li>
+      <li class="flex flex-col items-center">
+        <span class="text-xl">📰</span>
+        <span>News</span>
+      </li>
+      <li class="flex flex-col items-center">
+        <span class="text-xl">🛡️</span>
+        <span>Safer Use</span>
+      </li>
+      <li class="flex flex-col items-center">
+        <span class="text-xl">🗺️</span>
+        <span>Map</span>
+      </li>
+    </ul>
+  </nav>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh `homescreen.html` with a simplified layout
- add 'Heute für dich' cards
- include sticky bottom navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686429375328833286a33c7b89fa3251