### PR TITLE
Add bottom navigation with icons

### DIFF
--- a/homescreen.html
+++ b/homescreen.html
@@ -66,26 +66,36 @@
 
   <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg pb-[env(safe-area-inset-bottom)]">
     <div class="max-w-md mx-auto px-4">
-      <ul class="flex justify-between items-center gap-x-2 py-2 text-sm">
-        <li class="flex flex-col items-center">
-          <span class="text-xl">🌿</span>
-          <span>Strains</span>
+      <ul class="flex justify-between items-center gap-x-2 py-2 text-xs">
+        <li>
+          <a href="strains.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/strains.svg" alt="Strains" class="w-6 h-6 mb-0.5">
+            <span>Strains</span>
+          </a>
         </li>
-        <li class="flex flex-col items-center">
-          <span class="text-xl">🔍</span>
-          <span>Finder</span>
+        <li>
+          <a href="strain-finder.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/finder.svg" alt="Finder" class="w-6 h-6 mb-0.5">
+            <span>Finder</span>
+          </a>
         </li>
-        <li class="flex flex-col items-center">
-          <span class="text-xl">📰</span>
-          <span>News</span>
+        <li>
+          <a href="news.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/news.svg" alt="News" class="w-6 h-6 mb-0.5">
+            <span>News</span>
+          </a>
         </li>
-        <li class="flex flex-col items-center">
-          <span class="text-xl">🛡️</span>
-          <span>Safer Use</span>
+        <li>
+          <a href="safe-use.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/safe.svg" alt="Safer Use" class="w-6 h-6 mb-0.5">
+            <span>Safer Use</span>
+          </a>
         </li>
-        <li class="flex flex-col items-center">
-          <span class="text-xl">🗺️</span>
-          <span>Map</span>
+        <li>
+          <a href="map.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/map.svg" alt="Map" class="w-6 h-6 mb-0.5">
+            <span>Map</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/icons/finder.svg
+++ b/icons/finder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="11" cy="11" r="7"/>
+  <line x1="16" y1="16" x2="22" y2="22"/>
+</svg>

--- a/icons/map.svg
+++ b/icons/map.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2a7 7 0 00-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 00-7-7zm0 9a2 2 0 110-4 2 2 0 010 4z"/>
+</svg>

--- a/icons/news.svg
+++ b/icons/news.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="16" rx="2"/>
+  <path d="M7 8h10M7 12h10M7 16h4"/>
+</svg>

--- a/icons/safe.svg
+++ b/icons/safe.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2l7 4v5c0 5-3 9.5-7 11-4-1.5-7-6-7-11V6l7-4z"/>
+</svg>

--- a/icons/strains.svg
+++ b/icons/strains.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2c-.8 3.1-2.9 5.3-6 6 3.1.7 5.2 2.9 6 6 .8-3.1 2.9-5.3 6-6-3.1-.7-5.2-2.9-6-6z"/>
+</svg>


### PR DESCRIPTION
## Summary
- create minimal SVG icons for navigation
- update homescreen navigation with links and icon images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686431bd99d08332b76b0081b05f944d