### PR TITLE
Add strains overview with cards

### DIFF
--- a/strains.html
+++ b/strains.html
@@ -4,8 +4,243 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Strains</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
 </head>
-<body>
-  <h1>Strains-Seite</h1>
+<body class="bg-gray-100 text-gray-800 font-sans text-lg font-semibold tracking-wide flex flex-col min-h-screen">
+  <header class="bg-emerald-700 text-white py-4">
+    <div class="max-w-md mx-auto text-center">
+      <h1 class="text-2xl font-bold">CannabisApp</h1>
+    </div>
+  </header>
+
+  <main class="flex-1 max-w-md mx-auto p-4 pb-24">
+    <h2 class="text-xl text-emerald-700 mb-4">Beliebte Sorten</h2>
+
+    <!-- Amnesia Haze -->
+    <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+      <img src="https://via.placeholder.com/400x200.png?text=Amnesia+Haze" alt="Amnesia Haze" class="w-full h-40 object-cover">
+      <div class="p-4">
+        <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+        <h3 class="mt-2 text-lg font-bold">Amnesia Haze</h3>
+        <div class="mt-2 text-sm">
+          <div class="flex items-center mb-1">
+            <span class="w-12">THC</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:22%"></div>
+            </div>
+            <span>22%</span>
+          </div>
+          <div class="flex items-center">
+            <span class="w-12">CBD</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:1%"></div>
+            </div>
+            <span>1%</span>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-2 text-xl">
+          <span title="kreativ">🎨</span>
+          <span title="beruhigend">😌</span>
+        </div>
+        <div class="mt-2 text-yellow-500">★★★★☆</div>
+      </div>
+    </div>
+
+    <!-- Northern Lights -->
+    <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+      <img src="https://via.placeholder.com/400x200.png?text=Northern+Lights" alt="Northern Lights" class="w-full h-40 object-cover">
+      <div class="p-4">
+        <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+        <h3 class="mt-2 text-lg font-bold">Northern Lights</h3>
+        <div class="mt-2 text-sm">
+          <div class="flex items-center mb-1">
+            <span class="w-12">THC</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:18%"></div>
+            </div>
+            <span>18%</span>
+          </div>
+          <div class="flex items-center">
+            <span class="w-12">CBD</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:2%"></div>
+            </div>
+            <span>2%</span>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-2 text-xl">
+          <span title="entspannend">🛌</span>
+        </div>
+        <div class="mt-2 text-yellow-500">★★★★☆</div>
+      </div>
+    </div>
+
+    <!-- Charlotte's Web -->
+    <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+      <img src="https://via.placeholder.com/400x200.png?text=Charlottes+Web" alt="Charlotte's Web" class="w-full h-40 object-cover">
+      <div class="p-4">
+        <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+        <h3 class="mt-2 text-lg font-bold">Charlotte's Web</h3>
+        <div class="mt-2 text-sm">
+          <div class="flex items-center mb-1">
+            <span class="w-12">THC</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:1%"></div>
+            </div>
+            <span>1%</span>
+          </div>
+          <div class="flex items-center">
+            <span class="w-12">CBD</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:15%"></div>
+            </div>
+            <span>15%</span>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-2 text-xl">
+          <span title="medizinisch">💊</span>
+        </div>
+        <div class="mt-2 text-yellow-500">★★★★★</div>
+      </div>
+    </div>
+
+    <!-- Blue Dream -->
+    <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+      <img src="https://via.placeholder.com/400x200.png?text=Blue+Dream" alt="Blue Dream" class="w-full h-40 object-cover">
+      <div class="p-4">
+        <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+        <h3 class="mt-2 text-lg font-bold">Blue Dream</h3>
+        <div class="mt-2 text-sm">
+          <div class="flex items-center mb-1">
+            <span class="w-12">THC</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:17%"></div>
+            </div>
+            <span>17%</span>
+          </div>
+          <div class="flex items-center">
+            <span class="w-12">CBD</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:2%"></div>
+            </div>
+            <span>2%</span>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-2 text-xl">
+          <span title="ausgeglichen">⚖️</span>
+        </div>
+        <div class="mt-2 text-yellow-500">★★★★☆</div>
+      </div>
+    </div>
+
+    <!-- Super Lemon Haze -->
+    <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+      <img src="https://via.placeholder.com/400x200.png?text=Super+Lemon+Haze" alt="Super Lemon Haze" class="w-full h-40 object-cover">
+      <div class="p-4">
+        <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+        <h3 class="mt-2 text-lg font-bold">Super Lemon Haze</h3>
+        <div class="mt-2 text-sm">
+          <div class="flex items-center mb-1">
+            <span class="w-12">THC</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:20%"></div>
+            </div>
+            <span>20%</span>
+          </div>
+          <div class="flex items-center">
+            <span class="w-12">CBD</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:1%"></div>
+            </div>
+            <span>1%</span>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-2 text-xl">
+          <span title="anregend">⚡</span>
+        </div>
+        <div class="mt-2 text-yellow-500">★★★★☆</div>
+      </div>
+    </div>
+
+    <!-- White Widow -->
+    <div class="bg-white rounded-xl shadow mb-4 overflow-hidden">
+      <img src="https://via.placeholder.com/400x200.png?text=White+Widow" alt="White Widow" class="w-full h-40 object-cover">
+      <div class="p-4">
+        <span class="text-sm bg-emerald-100 text-emerald-700 px-2 py-1 rounded-full">Hybrid</span>
+        <h3 class="mt-2 text-lg font-bold">White Widow</h3>
+        <div class="mt-2 text-sm">
+          <div class="flex items-center mb-1">
+            <span class="w-12">THC</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:19%"></div>
+            </div>
+            <span>19%</span>
+          </div>
+          <div class="flex items-center">
+            <span class="w-12">CBD</span>
+            <div class="flex-1 bg-gray-200 rounded h-2 mx-2">
+              <div class="bg-emerald-500 h-2 rounded" style="width:1%"></div>
+            </div>
+            <span>1%</span>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-2 text-xl">
+          <span title="klassisch">🏆</span>
+        </div>
+        <div class="mt-2 text-yellow-500">★★★★☆</div>
+      </div>
+    </div>
+  </main>
+
+  <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg pb-[env(safe-area-inset-bottom)]">
+    <div class="max-w-md mx-auto px-4">
+      <ul class="flex justify-between items-center gap-x-2 py-2 text-xs">
+        <li>
+          <a href="strains.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/strains.svg" alt="Strains" class="w-6 h-6 mb-0.5">
+            <span>Strains</span>
+          </a>
+        </li>
+        <li>
+          <a href="finder.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/finder.svg" alt="Finder" class="w-6 h-6 mb-0.5">
+            <span>Finder</span>
+          </a>
+        </li>
+        <li>
+          <a href="news.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/news.svg" alt="News" class="w-6 h-6 mb-0.5">
+            <span>News</span>
+          </a>
+        </li>
+        <li>
+          <a href="safe-use.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/safe.svg" alt="Safer Use" class="w-6 h-6 mb-0.5">
+            <span>Safer Use</span>
+          </a>
+        </li>
+        <li>
+          <a href="map.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/map.svg" alt="Map" class="w-6 h-6 mb-0.5">
+            <span>Map</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build out `strains.html` with Tailwind CSS
- show six strain cards with THC/CBD bars, effect icons, and star ratings
- include bottom navigation to access the page from other views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643ab9d86483328576c4ccebbe57ff