### PR TITLE
Implement news page with Tailwind cards

### DIFF
--- a/news.html
+++ b/news.html
@@ -4,8 +4,84 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>News</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
 </head>
-<body>
-  <h1>News-Seite</h1>
+<body class="bg-gray-100 text-gray-800 font-sans text-lg font-semibold tracking-wide flex flex-col min-h-screen">
+  <header class="bg-emerald-700 text-white py-4">
+    <div class="max-w-md mx-auto text-center">
+      <h1 class="text-2xl font-bold">News</h1>
+    </div>
+  </header>
+
+  <main class="flex-1 max-w-md mx-auto p-4 pb-24">
+    <div class="space-y-4">
+      <article class="bg-white rounded-xl shadow p-4">
+        <h2 class="text-lg font-bold">Cannabisgesetz tritt 2024 in Kraft</h2>
+        <p class="mt-1 text-sm">Die Bundesregierung verabschiedet ein neues Gesetz zur Teillegalisierung von Cannabis...</p>
+        <a href="#" class="text-blue-600 underline mt-2 inline-block">Mehr lesen</a>
+      </article>
+      <article class="bg-white rounded-xl shadow p-4">
+        <h2 class="text-lg font-bold">Medizinisches Cannabis auf Rezept vereinfacht</h2>
+        <p class="mt-1 text-sm">Krankenkassen sollen künftig leichter Cannabistherapien genehmigen...</p>
+        <a href="#" class="text-blue-600 underline mt-2 inline-block">Mehr lesen</a>
+      </article>
+      <article class="bg-white rounded-xl shadow p-4">
+        <h2 class="text-lg font-bold">Studie untersucht Wirksamkeit bei Schmerzen</h2>
+        <p class="mt-1 text-sm">Forscher der Universität XY veröffentlichen neue Daten zum Einsatz von Cannabis bei chronischen Schmerzen...</p>
+        <a href="#" class="text-blue-600 underline mt-2 inline-block">Mehr lesen</a>
+      </article>
+    </div>
+  </main>
+
+  <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg pb-[env(safe-area-inset-bottom)]">
+    <div class="max-w-md mx-auto px-4">
+      <ul class="flex justify-between items-center gap-x-2 py-2 text-xs">
+        <li>
+          <a href="strains.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/strains.svg" alt="Strains" class="w-6 h-6 mb-0.5">
+            <span>Strains</span>
+          </a>
+        </li>
+        <li>
+          <a href="finder.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/finder.svg" alt="Finder" class="w-6 h-6 mb-0.5">
+            <span>Finder</span>
+          </a>
+        </li>
+        <li>
+          <a href="news.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/news.svg" alt="News" class="w-6 h-6 mb-0.5">
+            <span>News</span>
+          </a>
+        </li>
+        <li>
+          <a href="safe-use.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/safe.svg" alt="Safer Use" class="w-6 h-6 mb-0.5">
+            <span>Safer Use</span>
+          </a>
+        </li>
+        <li>
+          <a href="map.html" class="flex flex-col items-center text-gray-700 hover:text-emerald-700">
+            <img src="icons/map.svg" alt="Map" class="w-6 h-6 mb-0.5">
+            <span>Map</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build news.html using Tailwind CSS
- add sample news article cards with title, preview and "Mehr lesen" links
- include bottom navigation matching other pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68643b2974408332b0b083e74ca35b09