### PR TITLE
Ensure missing strain images show placeholder

### DIFF
--- a/strain.html
+++ b/strain.html
@@ -88,14 +88,20 @@
       }
       const description = strain.beschreibung || 'Beschreibung folgt.';
       const img = document.createElement('img');
-      img.src = strain.image;
-      img.alt = strain.name;
       img.className = 'w-full h-40 object-cover rounded-xl mb-4';
+      img.alt = strain.name;
 
       const placeholder = document.createElement('div');
       placeholder.textContent = 'Bild folgt';
       placeholder.className = 'w-full h-40 bg-gray-100 text-gray-400 flex items-center justify-center rounded-xl mb-4';
       placeholder.style.display = 'none';
+
+      if (strain.image) {
+        img.src = strain.image;
+      } else {
+        img.style.display = 'none';
+        placeholder.style.display = 'flex';
+      }
 
       img.onerror = () => {
         img.style.display = 'none';

--- a/strains.html
+++ b/strains.html
@@ -88,14 +88,20 @@
         a.className = 'block bg-white rounded-xl shadow overflow-hidden';
 
         const img = document.createElement('img');
-        img.src = s.image;
-        img.alt = s.name;
         img.className = 'w-full h-40 object-cover rounded-t-md';
+        img.alt = s.name;
 
         const placeholder = document.createElement('div');
         placeholder.textContent = 'Bild folgt';
         placeholder.className = 'w-full h-40 bg-gray-100 text-gray-400 flex items-center justify-center rounded-t-md';
         placeholder.style.display = 'none';
+
+        if (s.image) {
+          img.src = s.image;
+        } else {
+          img.style.display = 'none';
+          placeholder.style.display = 'flex';
+        }
 
         img.onerror = () => {
           img.style.display = 'none';


### PR DESCRIPTION
## Summary
- show placeholder image when `image` field missing
- handle same logic on strain detail page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686500d9338c8332a742d633f5371fd6