### PR TITLE
Refresh trading dashboards UI

### DIFF
--- a/automation.html
+++ b/automation.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Automation Rules · CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Outfit', 'sans-serif']
+          },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            warning: '#FF9F4D'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="min-h-screen bg-[#040015] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#020012] via-[#060529] to-[#001F36]"></div>
+    <div class="absolute -top-36 -left-28 h-96 w-96 rounded-full bg-[#2971FF]/15 blur-3xl"></div>
+    <div class="absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-[#2AF7FF]/15 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.08),_transparent_55%)]"></div>
+
+    <div class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-10">
+      <header class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.5em] text-white/50">Automations</p>
+          <h1 class="mt-3 text-4xl font-semibold">Automation Rules</h1>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+          <a href="index.html" class="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 transition hover:bg-white/10">Zurück zum Center</a>
+          <button class="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2">
+            <span>Preset speichern</span>
+            <span class="text-lg">💾</span>
+          </button>
+        </div>
+      </header>
+
+      <main class="mt-10 flex-1">
+        <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-8 shadow-[0_40px_120px_-60px_rgba(42,247,255,0.45)] backdrop-blur-2xl">
+          <div class="flex flex-wrap items-center gap-3 border-b border-white/10 pb-6 text-sm uppercase tracking-[0.4em] text-white/50">
+            <span class="flex items-center gap-2 text-primary">
+              <span class="inline-flex h-2 w-2 rounded-full bg-accent"></span>
+              Automations Live
+            </span>
+            <span class="rounded-full border border-white/10 px-3 py-1 text-[11px] text-white/60">5 aktive Regeln</span>
+          </div>
+
+          <div class="mt-8 space-y-6 text-sm text-white/80">
+            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 backdrop-blur-xl">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                <span>Chat</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Is GoldTrading VIP</span>
+                <span>and Pair is</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">XAUUSD, XAGUSD</span>
+                <span>Confidence &gt; 8%</span>
+              </div>
+              <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+                <span class="rounded-full border border-accent/40 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                <span>Execute trade</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">With</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Risk Setting: Fixed %</span>
+                <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Protokoll</button>
+              </div>
+            </article>
+
+            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 backdrop-blur-xl">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                <span>Chat</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Is Premium Forex Signals</span>
+                <span>and Pair is not</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">GBPUSD</span>
+              </div>
+              <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+                <span class="rounded-full border border-accent/40 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                <span>Mute chat for</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Duration 12 h</span>
+                <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Details</button>
+              </div>
+            </article>
+
+            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 backdrop-blur-xl">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                <span>Chat</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Is Any</span>
+                <span>and Slippage &gt;</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">0,5</span>
+              </div>
+              <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+                <span class="rounded-full border border-accent/40 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                <span>Notify via Telegram</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">With Alert Preset: High</span>
+                <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Logs</button>
+              </div>
+            </article>
+
+            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 backdrop-blur-xl">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                <span>Latency</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">is &gt; 120 ms</span>
+                <span>and</span>
+                <span class="rounded-xl border border-warning/40 bg-warning/15 px-3 py-1 text-warning">Broker = Backup</span>
+              </div>
+              <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+                <span class="rounded-full border border-accent/40 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                <span>Execute trade</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Choose chat</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1">Add ×</span>
+                <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Fallback</button>
+              </div>
+            </article>
+
+            <article class="rounded-3xl border border-dashed border-white/20 bg-white/5/20 bg-clip-padding p-6 text-white/60 backdrop-blur-xl">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-[11px] uppercase tracking-[0.3em]">If</span>
+                <span>Signal</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">is</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">Choose condition</span>
+              </div>
+              <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+                <span class="rounded-full border border-accent/20 bg-accent/5 px-3 py-1 text-[11px] uppercase tracking-[0.3em]">Then</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">Execute trade</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">Risk Parameter</span>
+                <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">+</span>
+              </div>
+            </article>
+          </div>
+
+          <div class="mt-8 flex items-center justify-between">
+            <button class="rounded-2xl border border-white/10 bg-white/10 px-5 py-3 text-sm text-white/70">Historie</button>
+            <button class="rounded-2xl border border-accent/40 bg-gradient-to-r from-primary to-accent px-6 py-3 text-sm font-semibold text-[#041221] shadow-[0_25px_60px_-40px_rgba(60,255,110,0.7)]">+ Add Rule</button>
+          </div>
+        </section>
+      </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/chat-stats.html
+++ b/chat-stats.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chat-Statistiken · CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Outfit', 'sans-serif']
+          },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            purple: '#7A5CFF'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="min-h-screen bg-[#050011] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#030014] via-[#070830] to-[#02142D]"></div>
+    <div class="absolute -top-36 -left-32 h-96 w-96 rounded-full bg-[#2F6DFF]/15 blur-3xl"></div>
+    <div class="absolute -bottom-40 -right-28 h-96 w-96 rounded-full bg-[#25F4C7]/15 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(60,255,200,0.08),_transparent_55%)]"></div>
+
+    <div class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-10">
+      <header class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.5em] text-white/50">Chat-Statistiken</p>
+          <h1 class="mt-3 text-4xl font-semibold">Gold Trading VIP</h1>
+        </div>
+        <div class="flex flex-wrap items-center gap-3">
+          <a href="index.html" class="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70 transition hover:bg-white/10">Zurück</a>
+          <button class="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70">Export CSV</button>
+        </div>
+      </header>
+
+      <main class="mt-10 grid flex-1 gap-8 lg:grid-cols-[1.7fr_1fr]">
+        <section class="space-y-6">
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-5 backdrop-blur-2xl">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Winrate</p>
+              <p class="mt-2 text-3xl font-semibold text-accent">69,4%</p>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-5 backdrop-blur-2xl">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">R / R</p>
+              <p class="mt-2 text-3xl font-semibold">2,18</p>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-5 backdrop-blur-2xl">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Signals</p>
+              <p class="mt-2 text-3xl font-semibold">125</p>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-5 backdrop-blur-2xl">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Profit</p>
+              <p class="mt-2 text-3xl font-semibold text-primary">+ 9.432 €</p>
+            </div>
+          </div>
+
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
+              <h2 class="text-lg font-semibold">Session Heatmap</h2>
+              <div class="ml-auto flex items-center gap-2 text-xs uppercase tracking-[0.25em] text-white/50">
+                <span>00</span><span>03</span><span>06</span><span>09</span><span>12</span><span>15</span><span>18</span><span>21</span>
+              </div>
+            </div>
+            <div class="mt-6 grid grid-cols-8 gap-2">
+              <div class="space-y-2 text-xs text-white/40">
+                <span>Mo</span>
+                <span>Di</span>
+                <span>Mi</span>
+                <span>Do</span>
+                <span>Fr</span>
+                <span>Sa</span>
+                <span>So</span>
+              </div>
+              <div class="col-span-7 grid grid-cols-7 gap-2">
+                <div class="h-6 rounded-md bg-primary/10"></div>
+                <div class="h-6 rounded-md bg-primary/20"></div>
+                <div class="h-6 rounded-md bg-purple/30"></div>
+                <div class="h-6 rounded-md bg-purple/50"></div>
+                <div class="h-6 rounded-md bg-purple/70"></div>
+                <div class="h-6 rounded-md bg-purple/40"></div>
+                <div class="h-6 rounded-md bg-primary/15"></div>
+                <div class="h-6 rounded-md bg-primary/5"></div>
+                <div class="h-6 rounded-md bg-primary/15"></div>
+                <div class="h-6 rounded-md bg-purple/40"></div>
+                <div class="h-6 rounded-md bg-purple/70"></div>
+                <div class="h-6 rounded-md bg-purple/50"></div>
+                <div class="h-6 rounded-md bg-primary/20"></div>
+                <div class="h-6 rounded-md bg-primary/10"></div>
+                <div class="h-6 rounded-md bg-primary/5"></div>
+                <div class="h-6 rounded-md bg-primary/15"></div>
+                <div class="h-6 rounded-md bg-purple/60"></div>
+                <div class="h-6 rounded-md bg-purple/80"></div>
+                <div class="h-6 rounded-md bg-purple/50"></div>
+                <div class="h-6 rounded-md bg-primary/20"></div>
+                <div class="h-6 rounded-md bg-primary/15"></div>
+                <div class="h-6 rounded-md bg-primary/10"></div>
+                <div class="h-6 rounded-md bg-primary/5"></div>
+                <div class="h-6 rounded-md bg-primary/20"></div>
+                <div class="h-6 rounded-md bg-purple/60"></div>
+                <div class="h-6 rounded-md bg-purple/30"></div>
+                <div class="h-6 rounded-md bg-primary/15"></div>
+                <div class="h-6 rounded-md bg-primary/5"></div>
+                <div class="h-6 rounded-md bg-primary/10"></div>
+                <div class="h-6 rounded-md bg-primary/20"></div>
+                <div class="h-6 rounded-md bg-purple/70"></div>
+                <div class="h-6 rounded-md bg-purple/60"></div>
+                <div class="h-6 rounded-md bg-purple/40"></div>
+                <div class="h-6 rounded-md bg-primary/15"></div>
+                <div class="h-6 rounded-md bg-primary/5"></div>
+                <div class="h-6 rounded-md bg-primary/10"></div>
+                <div class="h-6 rounded-md bg-primary/20"></div>
+                <div class="h-6 rounded-md bg-purple/50"></div>
+              </div>
+            </div>
+          </section>
+        </section>
+
+        <aside class="space-y-6">
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 text-center backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Pair Distribution</h3>
+            <div class="mt-6 flex items-center justify-center">
+              <div class="relative h-40 w-40">
+                <div class="absolute inset-0 rounded-full border border-white/10 bg-gradient-to-br from-primary/30 to-purple/30"></div>
+                <div class="absolute inset-6 rounded-full border border-white/10 bg-[#050011]"></div>
+                <div class="absolute inset-[1.4rem] flex flex-col items-center justify-center rounded-full bg-[#050011] text-center">
+                  <span class="text-2xl font-semibold">60%</span>
+                  <span class="text-xs uppercase tracking-[0.25em] text-white/50">EUR/USD</span>
+                </div>
+              </div>
+            </div>
+            <p class="mt-4 text-sm text-white/60">GBP/USD 30% · Sonstige 10%</p>
+          </section>
+
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Accuracy by Pair</h3>
+            <div class="mt-6 space-y-4">
+              <div class="flex items-center justify-between">
+                <span class="text-sm text-white/60">EUR/USD</span>
+                <span class="text-base font-semibold text-accent">70%</span>
+              </div>
+              <div class="flex h-3 overflow-hidden rounded-full bg-white/10">
+                <div class="w-[70%] bg-gradient-to-r from-primary to-accent"></div>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="text-sm text-white/60">GBP/USD</span>
+                <span class="text-base font-semibold text-accent">90%</span>
+              </div>
+              <div class="flex h-3 overflow-hidden rounded-full bg-white/10">
+                <div class="w-[90%] bg-gradient-to-r from-purple to-accent"></div>
+              </div>
+            </div>
+
+            <div class="mt-6 flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4 text-sm">
+              <span>Alert Quality Score</span>
+              <span class="text-xl font-semibold text-primary">0,7</span>
+            </div>
+          </section>
+
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Latenz</h3>
+            <p class="mt-2 text-3xl font-semibold text-primary">210 ms</p>
+            <p class="mt-1 text-sm text-white/60">Median der letzten 7 Tage</p>
+          </section>
+        </aside>
+      </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="automation.html">Automationen</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
           colors: {
             safe: '#16F79A',
             danger: '#FF4F6D'
+          },
+          boxShadow: {
+            glass: '0 40px 120px -60px rgba(33, 173, 255, 0.45)'
           }
         }
       }
@@ -29,25 +32,29 @@
     <div class="absolute inset-0 bg-gradient-to-br from-[#040012] via-[#060220] to-[#001A2E]"></div>
     <div class="absolute -top-40 -left-24 h-96 w-96 rounded-full bg-[#22B5FF]/10 blur-3xl"></div>
     <div class="absolute -bottom-32 -right-28 h-96 w-96 rounded-full bg-[#17F7AA]/10 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(47,125,255,0.08),_transparent_55%)]"></div>
 
     <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10">
       <header class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <p class="uppercase tracking-[0.5em] text-xs text-white/50">Risk Control Center</p>
           <h1 class="mt-3 text-4xl font-semibold text-white">Kontrollzentrum</h1>
-          <p class="mt-2 max-w-xl text-base text-white/60">Behalte deine Handels-Bots, Live-Signale und die aktuelle Risikolage im Blick. Passe Limite und Hedging mit wenigen Klicks an.</p>
+          <p class="mt-2 max-w-xl text-base text-white/60">Behalte deine Handels-Bots, Live-Signale und die aktuelle Risikolage im Blick. Passe Limits und Hedging mit wenigen Klicks an.</p>
         </div>
         <div class="flex items-center gap-3 self-start lg:self-end">
           <button class="h-11 w-11 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl text-lg">🔔</button>
           <button class="h-11 w-11 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl text-lg">⚙️</button>
+          <a href="start.html" class="flex h-11 w-28 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/10 text-sm font-semibold text-white/80 transition hover:bg-white/15">
+            <span>Onboarding</span>
+          </a>
           <button class="h-11 w-11 rounded-2xl border border-white/10 bg-gradient-to-br from-[#2AF7FF]/80 to-[#3CFF6E]/80 text-[#021222] font-semibold">JD</button>
         </div>
       </header>
 
-      <main class="mt-12 grid flex-1 gap-8 lg:grid-cols-[1.7fr_1fr]">
+      <main class="mt-12 grid flex-1 gap-8 lg:grid-cols-[1.75fr_1fr]">
         <section class="space-y-8">
           <div class="grid gap-6 md:grid-cols-2">
-            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 shadow-[0_25px_80px_-60px_rgba(22,247,154,0.8)]">
+            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 shadow-[0_25px_80px_-60px_rgba(22,247,154,0.6)] backdrop-blur-2xl">
               <div class="flex items-center justify-between">
                 <div class="flex items-center gap-3">
                   <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#093726]/70 text-2xl">🛡️</span>
@@ -61,7 +68,7 @@
               <p class="mt-4 text-sm text-white/60">Alle Limits werden eingehalten. Offene Positionen verhalten sich im Rahmen deiner Risikostrategie.</p>
             </article>
 
-            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 shadow-[0_25px_80px_-60px_rgba(255,79,109,0.8)]">
+            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 shadow-[0_25px_80px_-60px_rgba(255,79,109,0.65)] backdrop-blur-2xl">
               <div class="flex items-center justify-between">
                 <div class="flex items-center gap-3">
                   <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#3B0E1B]/70 text-2xl">🚨</span>
@@ -76,13 +83,16 @@
             </article>
           </div>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
-            <div class="flex items-center justify-between">
+          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
               <div>
                 <h3 class="text-lg font-semibold">Exposure by Symbol</h3>
                 <p class="text-sm text-white/50">Verteilung aller aktiven Bots nach Underlying</p>
               </div>
-              <button class="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Anpassen</button>
+              <div class="ml-auto flex gap-2">
+                <button class="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Anpassen</button>
+                <a href="performance.html" class="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Performance</a>
+              </div>
             </div>
             <div class="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
               <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
@@ -118,15 +128,15 @@
             </div>
           </section>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
+          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
             <div class="flex flex-wrap items-center gap-4">
               <h3 class="text-lg font-semibold">Open Signals</h3>
-              <div class="flex gap-4 text-sm text-white/50">
+              <div class="flex flex-wrap gap-4 text-sm text-white/50">
                 <span>Limits 1.2%</span>
                 <span>Max Drawdown € 10,5k</span>
                 <span>Daily Loss € 4,5k</span>
               </div>
-              <button class="ml-auto rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Logs</button>
+              <a href="chat-stats.html" class="ml-auto rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Chat Stats</a>
             </div>
             <div class="mt-6 space-y-4">
               <article class="rounded-2xl border border-white/10 bg-white/5 p-4">
@@ -254,7 +264,7 @@
         </section>
 
         <aside class="space-y-8">
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 text-center shadow-[0_25px_80px_-60px_rgba(34,181,255,0.8)]">
+          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 text-center shadow-[0_25px_80px_-60px_rgba(34,181,255,0.8)] backdrop-blur-2xl">
             <p class="text-sm uppercase tracking-[0.3em] text-white/60">Open Signals</p>
             <div class="mt-4 flex flex-col items-center justify-center gap-6">
               <div class="relative flex h-40 w-40 items-center justify-center">
@@ -283,7 +293,7 @@
             </div>
           </section>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
+          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
             <h3 class="text-lg font-semibold">Session Limits</h3>
             <p class="mt-2 text-sm text-white/60">Setze präventive Limits für automatische Notabschaltungen, sobald dein Verlust oder die Latenz zu groß werden.</p>
             <div class="mt-6 space-y-4">
@@ -292,7 +302,7 @@
                   <p class="text-xs uppercase tracking-[0.2em] text-white/50">Max Drawdown</p>
                   <p class="mt-1 text-lg font-semibold">€ 12,5k</p>
                 </div>
-                <button class="rounded-xl border border-white/10 bg-gradient-to-r from-[#2AF7FF] to-[#3CFF6E] px-4 py-2 text-xs font-semibold text-[#021222]">Anpassen</button>
+                <a href="automation.html" class="rounded-xl border border-white/10 bg-gradient-to-r from-[#2AF7FF] to-[#3CFF6E] px-4 py-2 text-xs font-semibold text-[#021222]">Anpassen</a>
               </div>
               <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
                 <div>
@@ -311,7 +321,7 @@
             </div>
           </section>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
+          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
             <h3 class="text-lg font-semibold">Compliance &amp; Security</h3>
             <div class="mt-4 space-y-4 text-sm text-white/60">
               <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
@@ -335,9 +345,11 @@
 
       <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
         <span>© 2024 CannabisApp · Trading Automation Suite</span>
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="start.html">Onboarding</a>
-          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="homescreen.html">Classic UI</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="automation.html">Automationen</a>
         </div>
       </footer>
     </div>

--- a/performance.html
+++ b/performance.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Trading Bot Performance · CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Outfit', 'sans-serif']
+          },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="min-h-screen bg-[#050010] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#040015] via-[#06062C] to-[#02162F]"></div>
+    <div class="absolute -top-32 -left-28 h-96 w-96 rounded-full bg-[#2C7DFF]/10 blur-3xl"></div>
+    <div class="absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-[#25F4C7]/15 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(44,143,255,0.08),_transparent_60%)]"></div>
+
+    <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10">
+      <header class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.5em] text-white/50">Trading Bot Performance</p>
+          <h1 class="mt-3 text-4xl font-semibold">Performance Dashboard</h1>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+          <a href="index.html" class="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 transition hover:bg-white/10">Zurück zum Center</a>
+          <button class="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2">
+            <span>Jan 1, 2024 – Apr 25, 2024</span>
+            <span class="text-lg">📅</span>
+          </button>
+        </div>
+      </header>
+
+      <main class="mt-10 grid flex-1 gap-8 lg:grid-cols-[1.6fr_1fr]">
+        <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 shadow-[0_40px_120px_-60px_rgba(33,173,255,0.45)] backdrop-blur-2xl">
+          <div class="flex flex-wrap items-center gap-4">
+            <h2 class="text-lg font-semibold">Equity Curve</h2>
+            <div class="ml-auto flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.25em] text-white/60">
+              <span>Live</span>
+              <span class="inline-flex h-2 w-2 rounded-full bg-primary"></span>
+            </div>
+          </div>
+
+          <div class="relative mt-6 h-72 overflow-hidden rounded-3xl border border-white/5 bg-gradient-to-b from-white/10 to-transparent">
+            <div class="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(60,255,110,0.15),_transparent_55%)]"></div>
+            <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.04)_1px,transparent_1px)], bg-[length:80px_1px]"></div>
+            <div class="absolute inset-0 bg-[linear-gradient(to_top,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1px_60px]"></div>
+            <svg viewBox="0 0 800 320" class="relative h-full w-full">
+              <defs>
+                <linearGradient id="lineGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+                  <stop offset="0%" stop-color="#2AF7FF" />
+                  <stop offset="100%" stop-color="#3CFF6E" />
+                </linearGradient>
+              </defs>
+              <path d="M0 260 Q120 220 180 230 T320 170 T460 190 T640 110 T800 80" stroke="url(#lineGradient)" stroke-width="6" fill="none" stroke-linecap="round"></path>
+              <path d="M0 320 L0 260 Q120 220 180 230 T320 170 T460 190 T640 110 T800 80 L800 320 Z" fill="url(#lineGradient)" opacity="0.15"></path>
+            </svg>
+            <div class="absolute bottom-4 right-4 rounded-2xl border border-white/10 bg-black/40 px-3 py-2 text-xs text-white/70 backdrop-blur">
+              Letztes Update: 08:45 Uhr
+            </div>
+          </div>
+
+          <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Sharpe</p>
+              <p class="mt-2 text-3xl font-semibold">1,45</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Sortino</p>
+              <p class="mt-2 text-3xl font-semibold">2,30</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Max Drawdown</p>
+              <p class="mt-2 text-3xl font-semibold text-danger">-13,7%</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <p class="text-xs uppercase tracking-[0.3em] text-white/50">Win Rate</p>
+              <p class="mt-2 text-3xl font-semibold text-accent">67,5%</p>
+            </div>
+          </div>
+        </section>
+
+        <aside class="space-y-6">
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Profit</h3>
+            <p class="mt-1 text-3xl font-semibold text-accent">+ 4.453 €</p>
+            <p class="mt-2 text-sm text-white/60">Bruttorendite seit Jahresbeginn</p>
+          </section>
+
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Monthly Profit</h3>
+            <div class="mt-5 grid grid-cols-7 gap-2 text-center text-[11px] text-white/40">
+              <span>M</span><span>D</span><span>M</span><span>D</span><span>F</span><span>S</span><span>S</span>
+            </div>
+            <div class="mt-3 grid grid-cols-7 gap-2">
+              <div class="h-10 rounded-lg bg-primary/5"></div>
+              <div class="h-10 rounded-lg bg-primary/10"></div>
+              <div class="h-10 rounded-lg bg-primary/30"></div>
+              <div class="h-10 rounded-lg bg-accent/40"></div>
+              <div class="h-10 rounded-lg bg-accent/70"></div>
+              <div class="h-10 rounded-lg bg-accent/40"></div>
+              <div class="h-10 rounded-lg bg-primary/20"></div>
+              <div class="h-10 rounded-lg bg-primary/15"></div>
+              <div class="h-10 rounded-lg bg-primary/5"></div>
+              <div class="h-10 rounded-lg bg-accent/30"></div>
+              <div class="h-10 rounded-lg bg-accent/60"></div>
+              <div class="h-10 rounded-lg bg-accent/20"></div>
+              <div class="h-10 rounded-lg bg-primary/10"></div>
+              <div class="h-10 rounded-lg bg-primary/5"></div>
+            </div>
+          </section>
+
+          <section class="rounded-[32px] border border-white/10 bg-white/5/10 bg-clip-padding p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Profit Distribution</h3>
+            <div class="mt-6 space-y-2">
+              <div class="flex items-end gap-2">
+                <div class="flex-1 rounded-t-lg bg-primary/30" style="height: 60px"></div>
+                <div class="flex-1 rounded-t-lg bg-primary/40" style="height: 120px"></div>
+                <div class="flex-1 rounded-t-lg bg-accent/70" style="height: 180px"></div>
+                <div class="flex-1 rounded-t-lg bg-primary/40" style="height: 100px"></div>
+                <div class="flex-1 rounded-t-lg bg-primary/20" style="height: 70px"></div>
+              </div>
+              <div class="flex justify-between text-xs text-white/40">
+                <span>-800</span>
+                <span>-200</span>
+                <span>0</span>
+                <span>400</span>
+                <span>800</span>
+              </div>
+            </div>
+          </section>
+        </aside>
+      </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="automation.html">Automationen</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/start.html
+++ b/start.html
@@ -23,53 +23,73 @@
     }
   </script>
 </head>
-<body class="min-h-screen bg-[#050111] text-white font-sans">
-  <div class="relative overflow-hidden min-h-screen flex items-center justify-center px-6 py-12">
-    <div class="absolute inset-0 bg-gradient-to-br from-[#050111] via-[#0B0A28] to-[#061835]"></div>
-    <div class="absolute -top-20 -left-24 h-72 w-72 rounded-full bg-[#1C69FF]/20 blur-3xl"></div>
-    <div class="absolute -bottom-24 -right-16 h-72 w-72 rounded-full bg-[#27EFB4]/10 blur-3xl"></div>
+<body class="min-h-screen bg-[#040010] text-white font-sans">
+  <div class="relative flex min-h-screen items-center justify-center overflow-hidden px-6 py-12">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#060018] via-[#050B2B] to-[#021B34]"></div>
+    <div class="absolute -top-40 -left-32 h-80 w-80 rounded-full bg-[#1E63FF]/20 blur-3xl"></div>
+    <div class="absolute -bottom-36 -right-20 h-80 w-80 rounded-full bg-[#21F1B1]/20 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(48,114,255,0.08),_transparent_55%)]"></div>
 
-    <div class="relative w-full max-w-sm">
-      <header class="text-center uppercase tracking-[0.3em] text-xs text-white/70">
-        <h1 class="text-3xl font-semibold tracking-[0.5em]">Onboarding</h1>
-        <div class="mt-8 flex items-center justify-between">
-          <div class="flex-1 flex justify-between px-1">
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-[#32E4FF] to-[#2AD8B6] text-sm font-semibold text-[#050111] shadow-onboarding">1</span>
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-white/5 text-sm font-semibold">2</span>
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">3</span>
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">4</span>
+    <div class="relative w-full max-w-md">
+      <header class="text-center text-white">
+        <p class="text-xs uppercase tracking-[0.55em] text-white/50">Onboarding</p>
+        <h1 class="mt-3 text-4xl font-semibold tracking-[0.25em]">Start</h1>
+
+        <div class="mt-8 flex items-center justify-between gap-4 text-sm font-medium">
+          <div class="flex flex-1 items-center justify-between gap-2">
+            <div class="flex flex-1 items-center">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-[#2CF4FF] to-[#36F6B0] text-sm font-semibold text-[#04111F] shadow-onboarding">1</span>
+              <span class="mx-1 h-[2px] flex-1 bg-gradient-to-r from-[#2CF4FF] to-transparent"></span>
+            </div>
+            <div class="flex flex-1 items-center">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/5 text-sm font-semibold text-white/80">2</span>
+              <span class="mx-1 h-[2px] flex-1 bg-white/10"></span>
+            </div>
+            <div class="flex flex-1 items-center">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">3</span>
+              <span class="mx-1 h-[2px] flex-1 bg-white/10"></span>
+            </div>
+            <div>
+              <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">4</span>
+            </div>
           </div>
         </div>
       </header>
 
-      <main class="mt-10 rounded-3xl border border-white/5 bg-white/5/10 bg-clip-padding backdrop-blur-xl p-8 shadow-[0_30px_60px_-40px_rgba(0,0,0,0.8)]">
-        <div class="flex items-center gap-3 text-[#33C7FF]">
-          <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#0E1B3B] text-xl">📨</span>
+      <main class="mt-10 rounded-[28px] border border-white/10 bg-white/5/10 bg-clip-padding p-8 shadow-[0_45px_120px_-60px_rgba(11,125,255,0.45)] backdrop-blur-2xl">
+        <div class="flex items-center gap-3">
+          <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#0A1E38] text-2xl">📨</span>
           <div>
-            <p class="text-sm uppercase tracking-[0.3em] text-white/60">Connect</p>
-            <h2 class="text-xl font-semibold">Telegram</h2>
+            <p class="text-xs uppercase tracking-[0.35em] text-white/45">Connect</p>
+            <h2 class="text-2xl font-semibold text-[#2CF4FF]">Telegram</h2>
           </div>
         </div>
 
-        <form class="mt-8 space-y-5">
+        <form class="mt-10 space-y-6">
           <div>
-            <label for="api-id" class="mb-2 block text-xs uppercase tracking-[0.3em] text-white/50">API ID</label>
-            <input id="api-id" type="text" value="1234567" class="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder-white/30 focus:border-[#33C7FF] focus:outline-none focus:ring-2 focus:ring-[#33C7FF]/40">
+            <label for="api-id" class="mb-2 block text-[11px] uppercase tracking-[0.35em] text-white/55">API ID</label>
+            <div class="relative">
+              <input id="api-id" type="text" value="1234567" class="w-full rounded-2xl border border-white/10 bg-[#050A1F]/60 px-4 py-3 text-base text-white placeholder-white/20 shadow-[0_10px_30px_-20px_rgba(0,0,0,0.6)] focus:border-[#2CF4FF] focus:outline-none focus:ring-2 focus:ring-[#2CF4FF]/40">
+              <span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-xs uppercase tracking-[0.2em] text-white/30">ID</span>
+            </div>
           </div>
           <div>
-            <label for="api-hash" class="mb-2 block text-xs uppercase tracking-[0.3em] text-white/50">API Hash</label>
-            <input id="api-hash" type="password" value="••••••••••" class="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder-white/30 focus:border-[#33C7FF] focus:outline-none focus:ring-2 focus:ring-[#33C7FF]/40">
+            <label for="api-hash" class="mb-2 block text-[11px] uppercase tracking-[0.35em] text-white/55">API Hash</label>
+            <div class="relative">
+              <input id="api-hash" type="password" value="••••••••••" class="w-full rounded-2xl border border-white/10 bg-[#050A1F]/60 px-4 py-3 text-base text-white placeholder-white/20 shadow-[0_10px_30px_-20px_rgba(0,0,0,0.6)] focus:border-[#36F6B0] focus:outline-none focus:ring-2 focus:ring-[#36F6B0]/40">
+              <span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-xs uppercase tracking-[0.2em] text-white/30">SEC</span>
+            </div>
           </div>
         </form>
 
-        <ol class="mt-8 space-y-2 text-sm text-white/70">
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">1.</span> Verbinde deinen Telegram-Account</li>
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">2.</span> Wähle deine Chats aus</li>
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">3.</span> Lege das Risikoniveau fest</li>
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">4.</span> Starte den Bot</li>
+        <ol class="mt-10 space-y-3 text-sm text-white/70">
+          <li class="flex items-center gap-3"><span class="flex h-6 w-6 items-center justify-center rounded-full bg-[#2CF4FF]/15 text-xs font-semibold text-[#2CF4FF]">1</span> Verbinde deinen Telegram-Account</li>
+          <li class="flex items-center gap-3"><span class="flex h-6 w-6 items-center justify-center rounded-full bg-[#2CF4FF]/15 text-xs font-semibold text-[#2CF4FF]">2</span> Wähle deine Chats aus</li>
+          <li class="flex items-center gap-3"><span class="flex h-6 w-6 items-center justify-center rounded-full bg-[#2CF4FF]/15 text-xs font-semibold text-[#2CF4FF]">3</span> Lege das Risikoniveau fest</li>
+          <li class="flex items-center gap-3"><span class="flex h-6 w-6 items-center justify-center rounded-full bg-[#2CF4FF]/15 text-xs font-semibold text-[#2CF4FF]">4</span> Starte den Bot</li>
         </ol>
 
-        <button class="mt-10 w-full rounded-2xl bg-gradient-to-r from-[#2AF7FF] via-[#2EF0B5] to-[#3CFF6E] px-6 py-4 text-lg font-semibold text-[#050111] shadow-[0_20px_60px_-30px_rgba(46,240,181,0.8)] transition-transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#2EF0B5] focus:ring-offset-[#050111]">Start Bot</button>
+        <button class="mt-12 w-full rounded-[22px] bg-gradient-to-r from-[#2CF4FF] via-[#30F2C6] to-[#3CFF6E] px-6 py-4 text-lg font-semibold text-[#04111F] shadow-[0_25px_80px_-40px_rgba(60,255,110,0.8)] transition-transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#30F2C6] focus:ring-offset-[#040010]">Start Bot</button>
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- rebuild the onboarding and risk center pages with neon-glass gradients inspired by the latest mockups
- add dedicated performance, chat statistics, and automation rule dashboards matching the provided layouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d01948ca9c83328ff2a9ece4ec7139