### PR TITLE
Align trading automation surfaces with screenshots

### DIFF
--- a/automation.html
+++ b/automation.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Automation Rules · CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Outfit', 'sans-serif']
+          },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            warning: '#FF9F4D',
+            danger: '#FF4F6D',
+            surface: 'rgba(5, 16, 37, 0.8)'
+          },
+          boxShadow: {
+            glass: '0 45px 140px -60px rgba(42, 247, 255, 0.55)'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="min-h-screen bg-[#030015] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#020012] via-[#06082B] to-[#001C34]"></div>
+    <div class="absolute -top-36 -left-32 h-96 w-96 rounded-full bg-[#2C7DFF]/25 blur-3xl"></div>
+    <div class="absolute -bottom-32 -right-24 h-96 w-96 rounded-full bg-[#25F4C7]/20 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.12),_transparent_60%)]"></div>
+
+    <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10">
+      <header class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.55em] text-white/50">Automations</p>
+          <h1 class="mt-2 text-4xl font-semibold">Automation Rules</h1>
+          <p class="mt-3 max-w-2xl text-sm text-white/60">Definiere präzise Handelslogiken, reagiere auf Latenzspitzen und sichere deine Portfolios mit automatisierten Fallbacks ab.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+          <a href="index.html" class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2 transition hover:bg-white/15">Zurück zum Center</a>
+          <button class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2">Preset speichern 💾</button>
+          <button class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-gradient-to-r from-primary to-accent px-4 py-2 text-[#021222] font-semibold">+ Neue Regel</button>
+        </div>
+      </header>
+
+      <main class="mt-10 grid flex-1 gap-8 lg:grid-cols-[1.45fr_1fr]">
+        <section class="space-y-6">
+          <article class="rounded-[34px] border border-white/10 bg-surface p-6 shadow-glass backdrop-blur-2xl">
+            <header class="flex flex-wrap items-center gap-3 border-b border-white/10 pb-6 text-xs uppercase tracking-[0.35em] text-white/60">
+              <span class="inline-flex items-center gap-2 text-primary">
+                <span class="inline-flex h-2 w-2 rounded-full bg-accent"></span>
+                Automations Live
+              </span>
+              <span class="rounded-full border border-white/10 px-3 py-1 text-[11px] text-white/60">5 aktive Regeln</span>
+              <span class="rounded-full border border-white/10 px-3 py-1 text-[11px] text-white/60">Latency Guard aktiv</span>
+            </header>
+
+            <div class="mt-8 space-y-5">
+              <article class="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl">
+                <header class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+                  <span class="rounded-full border border-primary/50 bg-primary/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                  <span>Chat</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">GoldTrading VIP</span>
+                  <span>Pair</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">XAUUSD · XAGUSD</span>
+                  <span>Confidence &gt; 8%</span>
+                </header>
+                <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4 text-sm text-white/70">
+                  <span class="rounded-full border border-accent/50 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                  <span>Trade ausführen</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Risk: Fixed %</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Hedging aktivieren</span>
+                  <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Protokoll</button>
+                </div>
+              </article>
+
+              <article class="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl">
+                <header class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+                  <span class="rounded-full border border-primary/50 bg-primary/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                  <span>Chat</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Premium Forex Signals</span>
+                  <span>Latency</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">&gt; 120 ms</span>
+                </header>
+                <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4 text-sm text-white/70">
+                  <span class="rounded-full border border-accent/50 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                  <span>Automation pausieren</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Alert senden</span>
+                  <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Fallback</button>
+                </div>
+              </article>
+
+              <article class="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl">
+                <header class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+                  <span class="rounded-full border border-primary/50 bg-primary/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                  <span>Signal</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Profit &lt; -500€</span>
+                  <span>Streak</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">3 trades</span>
+                </header>
+                <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4 text-sm text-white/70">
+                  <span class="rounded-full border border-accent/50 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                  <span>Volume halbieren</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Cooldown 6h</span>
+                  <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Details</button>
+                </div>
+              </article>
+
+              <article class="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl">
+                <header class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+                  <span class="rounded-full border border-primary/50 bg-primary/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-primary">If</span>
+                  <span>Broker</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Backup</span>
+                  <span>Latency</span>
+                  <span class="rounded-xl border border-warning/40 bg-warning/15 px-3 py-1 text-warning">&gt; 220 ms</span>
+                </header>
+                <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4 text-sm text-white/70">
+                  <span class="rounded-full border border-accent/50 bg-accent/15 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-accent">Then</span>
+                  <span>Wechsle zu</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Prime Broker</span>
+                  <span class="rounded-xl border border-white/10 bg-white/10 px-3 py-1">Notify Ops</span>
+                  <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">Logs</button>
+                </div>
+              </article>
+
+              <article class="rounded-3xl border border-dashed border-white/20 bg-white/5/20 p-6 text-white/60 backdrop-blur-xl">
+                <header class="flex flex-wrap items-center gap-3 text-sm">
+                  <span class="rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-[11px] uppercase tracking-[0.3em]">If</span>
+                  <span>Signal</span>
+                  <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">Bedingung wählen</span>
+                </header>
+                <div class="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4 text-sm">
+                  <span class="rounded-full border border-accent/20 bg-accent/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em]">Then</span>
+                  <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">Aktion hinzufügen</span>
+                  <span class="rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-white/70">+</span>
+                </div>
+              </article>
+            </div>
+          </article>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <header class="flex flex-wrap items-center gap-3">
+              <h2 class="text-lg font-semibold">Blueprint Builder</h2>
+              <span class="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/50">Beta</span>
+            </header>
+            <div class="mt-6 grid gap-4 md:grid-cols-2">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Input</p>
+                <p class="mt-2 text-sm text-white/70">Wähle Chat, Symbol oder Kennzahl</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Operator</p>
+                <p class="mt-2 text-sm text-white/70">Größer, kleiner, enthält, wechselt</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Aktion</p>
+                <p class="mt-2 text-sm text-white/70">Trade, Alert, Pause, Not-Aus</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Fallback</p>
+                <p class="mt-2 text-sm text-white/70">Switch Broker, Sende Report</p>
+              </div>
+            </div>
+            <button class="mt-6 inline-flex items-center gap-3 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-xs uppercase tracking-[0.25em] text-white/70">Vorlage speichern →</button>
+          </section>
+        </section>
+
+        <aside class="space-y-6">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Timeline</h3>
+            <div class="mt-5 space-y-4 text-sm text-white/60">
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">🟢</span>
+                <div>
+                  <p class="font-medium text-white">Rule 4 aktiviert</p>
+                  <p class="text-white/60">Backup Broker → Prime Broker bei Latenz &gt; 220 ms.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">🟡</span>
+                <div>
+                  <p class="font-medium text-white">Cooldown ausgelöst</p>
+                  <p class="text-white/60">Crypto Signals pausiert für 2h.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">🔴</span>
+                <div>
+                  <p class="font-medium text-white">Fallback gestartet</p>
+                  <p class="text-white/60">GoldTrading VIP wechselt auf Hedging-only.</p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Presets</h3>
+            <div class="mt-5 space-y-3 text-sm text-white/60">
+              <button class="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 transition hover:bg-white/10">
+                <span>London Session Boost</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Aktiv</span>
+              </button>
+              <button class="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 transition hover:bg-white/10">
+                <span>Asia Range Defense</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Standby</span>
+              </button>
+              <button class="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 transition hover:bg-white/10">
+                <span>Latency Shield</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Off</span>
+              </button>
+            </div>
+            <button class="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-xs uppercase tracking-[0.25em] text-white/70">Preset importieren</button>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Sicherheitscheck</h3>
+            <ul class="mt-4 space-y-3 text-sm text-white/65">
+              <li class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><span class="text-xl">✅</span><span>Not-Aus via SMS getestet</span></li>
+              <li class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><span class="text-xl">⚠️</span><span>2 Regeln ohne Fallback</span></li>
+              <li class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><span class="text-xl">⬜️</span><span>Webhook Monitoring aktivieren</span></li>
+            </ul>
+          </section>
+        </aside>
+      </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/chat-stats.html
+++ b/chat-stats.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chat Statistics · CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Outfit', 'sans-serif']
+          },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            warning: '#FF9F4D',
+            danger: '#FF4F6D',
+            surface: 'rgba(5, 18, 40, 0.78)'
+          },
+          boxShadow: {
+            glass: '0 45px 140px -60px rgba(42, 247, 255, 0.55)'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="min-h-screen bg-[#030015] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#020012] via-[#050A28] to-[#001B34]"></div>
+    <div class="absolute -top-40 -left-28 h-96 w-96 rounded-full bg-[#2C7DFF]/25 blur-3xl"></div>
+    <div class="absolute -bottom-36 -right-24 h-96 w-96 rounded-full bg-[#25F4C7]/20 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.12),_transparent_60%)]"></div>
+
+    <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10">
+      <header class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.55em] text-white/50">Chat Intelligence</p>
+          <h1 class="mt-2 text-4xl font-semibold">Chat Statistiken</h1>
+          <p class="mt-3 max-w-2xl text-sm text-white/60">Analysiere Signal-Feeds, Antwortzeiten und Engagement über alle Telegram-Channels hinweg. Identifiziere Volumen-Spitzen und Silence Phases.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+          <a href="index.html" class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2 transition hover:bg-white/15">Zurück zum Center</a>
+          <button class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2">Sync 08:46 · 🔄</button>
+          <button class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-gradient-to-r from-primary to-accent px-4 py-2 text-[#021222] font-semibold">Export</button>
+        </div>
+      </header>
+
+      <main class="mt-10 grid flex-1 gap-8 xl:grid-cols-[1.55fr_1fr]">
+        <section class="space-y-8">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 shadow-glass backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
+              <h2 class="text-lg font-semibold">Channel Übersicht</h2>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/50">Top Feeds</span>
+              <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Filter</button>
+            </div>
+            <div class="mt-6 space-y-4">
+              <div class="grid grid-cols-[auto_1fr_auto_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/20 text-lg">💬</span>
+                <div>
+                  <p class="font-semibold text-white">Premium Forex Signals</p>
+                  <p class="text-xs text-white/50">1h Takt · Moderiert</p>
+                </div>
+                <span class="text-sm font-semibold text-accent">128 Msg</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/50">Latency 1.2s</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/50">Engagement 67%</span>
+              </div>
+              <div class="grid grid-cols-[auto_1fr_auto_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-warning/20 text-lg">📈</span>
+                <div>
+                  <p class="font-semibold text-white">GoldTrading VIP</p>
+                  <p class="text-xs text-white/50">5m Takt · High Risk</p>
+                </div>
+                <span class="text-sm font-semibold text-warning">214 Msg</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/50">Latency 0.9s</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/50">Engagement 74%</span>
+              </div>
+              <div class="grid grid-cols-[auto_1fr_auto_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg">🪙</span>
+                <div>
+                  <p class="font-semibold text-white">Crypto Signals Pro</p>
+                  <p class="text-xs text-white/50">15m Takt · Momentum</p>
+                </div>
+                <span class="text-sm font-semibold text-accent">162 Msg</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/50">Latency 1.5s</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/50">Engagement 59%</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
+              <h2 class="text-lg font-semibold">Engagement &amp; Antworten</h2>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/50">24h</span>
+            </div>
+            <div class="mt-6 grid gap-4 md:grid-cols-3">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Ø Antwortzeit</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">2.3 s</p>
+                <p class="mt-3 text-xs text-white/50">95% innerhalb 6 Sekunden</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">User Reaktionen</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">+ 384</p>
+                <p class="mt-3 text-xs text-white/50">🔥 56 · 👍 184 · ⚠️ 12</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Silent Phases</p>
+                <p class="mt-2 text-2xl font-semibold text-white/80">3×</p>
+                <p class="mt-3 text-xs text-white/50">Longest: 18 Minuten</p>
+              </div>
+            </div>
+            <div class="mt-6 grid gap-4 md:grid-cols-2">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Peak Activity</p>
+                <p class="mt-2 text-lg font-semibold">London Open 09:15</p>
+                <p class="mt-3 text-xs text-white/50">142 Nachrichten in 15 Minuten</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Quiet Window</p>
+                <p class="mt-2 text-lg font-semibold">Asia Close 02:00</p>
+                <p class="mt-3 text-xs text-white/50">7 Nachrichten · Delay Trigger aktiv</p>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
+              <h2 class="text-lg font-semibold">Signal Breakdown</h2>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/50">Letzte 12h</span>
+            </div>
+            <div class="mt-6 space-y-4 text-sm text-white/70">
+              <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="inline-flex h-3 w-3 rounded-full bg-accent"></span>
+                <span class="flex-1">Long Signale</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">58%</span>
+                <span class="text-lg font-semibold text-accent">+ 1.120 €</span>
+              </div>
+              <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="inline-flex h-3 w-3 rounded-full bg-danger"></span>
+                <span class="flex-1">Short Signale</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">32%</span>
+                <span class="text-lg font-semibold text-danger">- 420 €</span>
+              </div>
+              <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="inline-flex h-3 w-3 rounded-full bg-warning"></span>
+                <span class="flex-1">Warnungen</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">10%</span>
+                <span class="text-lg font-semibold text-warning">12 Events</span>
+              </div>
+            </div>
+          </section>
+        </section>
+
+        <aside class="space-y-8">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 text-center shadow-glass backdrop-blur-2xl">
+            <p class="text-sm uppercase tracking-[0.3em] text-white/60">Live Traffic</p>
+            <div class="mt-6 flex flex-col items-center gap-6">
+              <div class="relative flex h-44 w-44 items-center justify-center">
+                <div class="absolute inset-4 rounded-full border-2 border-dashed border-white/10"></div>
+                <div class="absolute inset-0 rounded-full bg-gradient-to-br from-primary/25 to-accent/15 blur-xl"></div>
+                <div class="relative flex h-full w-full items-center justify-center rounded-full border border-white/10 bg-[#030015]/80"></div>
+                <div class="absolute flex h-24 w-24 flex-col items-center justify-center rounded-full bg-[#030015] text-center">
+                  <span class="text-3xl font-semibold text-primary">42</span>
+                  <span class="text-xs uppercase tracking-[0.25em] text-white/50">Msg/min</span>
+                </div>
+              </div>
+              <div class="grid w-full grid-cols-3 gap-3 text-sm">
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Live</p>
+                  <p class="mt-1 text-lg font-semibold">312</p>
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Alerts</p>
+                  <p class="mt-1 text-lg font-semibold text-warning">7</p>
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Muted</p>
+                  <p class="mt-1 text-lg font-semibold text-white/80">3</p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Antwortmatrix</h3>
+            <div class="mt-5 space-y-3 text-sm text-white/60">
+              <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>GoldTrading VIP</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Median 1.1s</span>
+                <span class="text-lg font-semibold text-accent">98%</span>
+              </div>
+              <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Premium Forex</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Median 1.6s</span>
+                <span class="text-lg font-semibold text-accent">92%</span>
+              </div>
+              <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Crypto Signals</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Median 2.4s</span>
+                <span class="text-lg font-semibold text-warning">84%</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Insights</h3>
+            <div class="mt-5 space-y-3 text-sm text-white/60">
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">💡</span>
+                <div>
+                  <p class="font-medium text-white">London Session übernimmt Volumen</p>
+                  <p class="text-white/60">83% der Reaktionen zwischen 8:30 und 10:00 Uhr.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">⚠️</span>
+                <div>
+                  <p class="font-medium text-white">Asia Range inaktiv</p>
+                  <p class="text-white/60">Silent Phase &gt; 20 Minuten · Automation vorschlagen.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">🛠️</span>
+                <div>
+                  <p class="font-medium text-white">Quick Reply Macros</p>
+                  <p class="text-white/60">Neue Shortcuts reduzieren Antwortzeit um 14%.</p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </aside>
+      </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="automation.html">Automationen</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,125 +16,166 @@
             sans: ['Outfit', 'sans-serif']
           },
           colors: {
-            safe: '#16F79A',
-            danger: '#FF4F6D'
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            safe: '#1CF59A',
+            danger: '#FF4F6D',
+            warning: '#FF9F4D',
+            surface: 'rgba(5, 12, 32, 0.75)'
+          },
+          boxShadow: {
+            glass: '0 45px 140px -60px rgba(42, 247, 255, 0.55)'
           }
         }
       }
     }
   </script>
 </head>
-<body class="min-h-screen bg-[#05010F] font-sans text-white">
+<body class="min-h-screen bg-[#030011] font-sans text-white">
   <div class="relative min-h-screen overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-[#040012] via-[#060220] to-[#001A2E]"></div>
-    <div class="absolute -top-40 -left-24 h-96 w-96 rounded-full bg-[#22B5FF]/10 blur-3xl"></div>
-    <div class="absolute -bottom-32 -right-28 h-96 w-96 rounded-full bg-[#17F7AA]/10 blur-3xl"></div>
+    <div class="absolute inset-0 bg-gradient-to-br from-[#020012] via-[#060826] to-[#001C35]"></div>
+    <div class="absolute -top-44 -left-32 h-96 w-96 rounded-full bg-[#2C7DFF]/25 blur-3xl"></div>
+    <div class="absolute -bottom-36 -right-24 h-96 w-96 rounded-full bg-[#25F4C7]/20 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.12),_transparent_60%)]"></div>
 
     <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10">
       <header class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <p class="uppercase tracking-[0.5em] text-xs text-white/50">Risk Control Center</p>
-          <h1 class="mt-3 text-4xl font-semibold text-white">Kontrollzentrum</h1>
-          <p class="mt-2 max-w-xl text-base text-white/60">Behalte deine Handels-Bots, Live-Signale und die aktuelle Risikolage im Blick. Passe Limite und Hedging mit wenigen Klicks an.</p>
+          <p class="text-xs uppercase tracking-[0.55em] text-white/50">Risk Control Center</p>
+          <h1 class="mt-2 text-4xl font-semibold">Trading Kontrollzentrum</h1>
+          <p class="mt-3 max-w-2xl text-base text-white/60">Überwache Bots, Exposure und Notabschaltungen in einem Dashboard. Verknüpfe Automationen, sichere Limits und Compliance-Benachrichtigungen in Echtzeit.</p>
         </div>
-        <div class="flex items-center gap-3 self-start lg:self-end">
-          <button class="h-11 w-11 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl text-lg">🔔</button>
-          <button class="h-11 w-11 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl text-lg">⚙️</button>
-          <button class="h-11 w-11 rounded-2xl border border-white/10 bg-gradient-to-br from-[#2AF7FF]/80 to-[#3CFF6E]/80 text-[#021222] font-semibold">JD</button>
+        <div class="flex flex-wrap items-center gap-3">
+          <button class="h-11 w-11 rounded-2xl border border-white/10 bg-white/10 text-lg text-white/80 backdrop-blur">🔔</button>
+          <button class="h-11 w-11 rounded-2xl border border-white/10 bg-white/10 text-lg text-white/80 backdrop-blur">⚙️</button>
+          <a href="start.html" class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/15">Onboarding</a>
+          <span class="inline-flex h-11 items-center gap-3 rounded-2xl border border-white/10 bg-gradient-to-br from-primary/80 to-accent/80 px-4 py-2 text-sm font-semibold text-[#021222]">JD · Admin</span>
         </div>
       </header>
 
-      <main class="mt-12 grid flex-1 gap-8 lg:grid-cols-[1.7fr_1fr]">
+      <main class="mt-12 grid flex-1 gap-8 xl:grid-cols-[1.55fr_1fr]">
         <section class="space-y-8">
-          <div class="grid gap-6 md:grid-cols-2">
-            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 shadow-[0_25px_80px_-60px_rgba(22,247,154,0.8)]">
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-3">
-                  <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#093726]/70 text-2xl">🛡️</span>
-                  <div>
-                    <p class="text-sm uppercase tracking-[0.3em] text-white/60">Status</p>
-                    <h2 class="text-3xl font-semibold text-safe">Safe</h2>
+          <div class="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+            <article class="relative overflow-hidden rounded-[34px] border border-white/10 bg-surface p-6 shadow-glass backdrop-blur-2xl">
+              <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.18),transparent_70%)]"></div>
+              <div class="relative flex flex-col gap-6">
+                <div class="flex flex-wrap items-center gap-4">
+                  <div class="flex items-center gap-3">
+                    <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#072D1F] text-2xl">🛡️</span>
+                    <div>
+                      <p class="text-xs uppercase tracking-[0.35em] text-white/50">Gesamtrisiko</p>
+                      <h2 class="text-3xl font-semibold text-safe">Safe</h2>
+                    </div>
+                  </div>
+                  <span class="inline-flex items-center gap-2 rounded-full border border-safe/40 bg-safe/10 px-4 py-1 text-xs uppercase tracking-[0.35em] text-safe">Live</span>
+                </div>
+                <p class="text-sm text-white/60">Alle Bots halten die Drawdown- und Latenzlimits ein. Es bestehen keine offenen Compliance-Sperren.</p>
+                <div class="grid gap-4 sm:grid-cols-3">
+                  <div class="rounded-2xl border border-white/10 bg-white/5/60 px-4 py-3">
+                    <p class="text-[11px] uppercase tracking-[0.25em] text-white/50">Aktive Bots</p>
+                    <p class="mt-2 text-2xl font-semibold">24</p>
+                  </div>
+                  <div class="rounded-2xl border border-white/10 bg-white/5/60 px-4 py-3">
+                    <p class="text-[11px] uppercase tracking-[0.25em] text-white/50">Auslastung</p>
+                    <p class="mt-2 text-2xl font-semibold">68%</p>
+                  </div>
+                  <div class="rounded-2xl border border-white/10 bg-white/5/60 px-4 py-3">
+                    <p class="text-[11px] uppercase tracking-[0.25em] text-white/50">Notabschaltung</p>
+                    <p class="mt-2 text-2xl font-semibold text-accent">Bereit</p>
                   </div>
                 </div>
-                <span class="rounded-full border border-safe/30 px-4 py-1 text-xs uppercase tracking-[0.3em] text-safe">Live</span>
               </div>
-              <p class="mt-4 text-sm text-white/60">Alle Limits werden eingehalten. Offene Positionen verhalten sich im Rahmen deiner Risikostrategie.</p>
             </article>
 
-            <article class="rounded-3xl border border-white/10 bg-white/5/20 bg-clip-padding p-6 shadow-[0_25px_80px_-60px_rgba(255,79,109,0.8)]">
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-3">
-                  <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#3B0E1B]/70 text-2xl">🚨</span>
-                  <div>
-                    <p class="text-sm uppercase tracking-[0.3em] text-white/60">Alert</p>
-                    <h2 class="text-3xl font-semibold text-danger">Emergency Flat</h2>
-                  </div>
+            <article class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+              <header class="flex items-center justify-between">
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-white/50">Signals Monitor</p>
+                  <h3 class="mt-2 text-xl font-semibold">Heatmap</h3>
                 </div>
-                <span class="rounded-full border border-danger/40 px-4 py-1 text-xs uppercase tracking-[0.3em] text-danger">1 aktiv</span>
+                <span class="text-sm text-white/50">Aktualisiert 08:47</span>
+              </header>
+              <div class="mt-6 space-y-4 text-sm text-white/60">
+                <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                  <span class="inline-flex h-3 w-3 rounded-full bg-accent"></span>
+                  <span class="flex-1">Premium Forex Signals</span>
+                  <span class="text-xs uppercase tracking-[0.25em] text-white/40">Low</span>
+                </div>
+                <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                  <span class="inline-flex h-3 w-3 rounded-full bg-warning"></span>
+                  <span class="flex-1">Commodities Zone</span>
+                  <span class="text-xs uppercase tracking-[0.25em] text-white/40">Medium</span>
+                </div>
+                <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                  <span class="inline-flex h-3 w-3 rounded-full bg-danger"></span>
+                  <span class="flex-1">Gold Trading VIP</span>
+                  <span class="text-xs uppercase tracking-[0.25em] text-white/40">High</span>
+                </div>
               </div>
-              <p class="mt-4 text-sm text-white/60">Gold-Strategie überschreitet Max-Drawdown. Automatisches Glattstellen in Vorbereitung.</p>
+              <a href="chat-stats.html" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-xs uppercase tracking-[0.25em] text-white/70 transition hover:bg-white/15">Chat Insights öffnen →</a>
             </article>
           </div>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
-            <div class="flex items-center justify-between">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
               <div>
-                <h3 class="text-lg font-semibold">Exposure by Symbol</h3>
+                <h3 class="text-lg font-semibold">Exposure nach Symbol</h3>
                 <p class="text-sm text-white/50">Verteilung aller aktiven Bots nach Underlying</p>
               </div>
-              <button class="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Anpassen</button>
+              <div class="ml-auto flex gap-2">
+                <button class="rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Anpassen</button>
+                <a href="performance.html" class="rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Performance</a>
+              </div>
             </div>
-            <div class="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-              <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                <span class="text-sm text-white/50">BTC</span>
-                <span class="text-2xl font-semibold">35%</span>
-                <span class="h-1 rounded-full bg-gradient-to-r from-[#2AF7FF] to-[#3CFF6E]"></span>
+            <div class="mt-6 space-y-4">
+              <div class="grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-sm text-white/60">BTC</span>
+                <div class="h-2 rounded-full bg-white/10">
+                  <div class="h-2 w-[72%] rounded-full bg-gradient-to-r from-primary to-accent"></div>
+                </div>
+                <span class="text-lg font-semibold">35%</span>
               </div>
-              <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                <span class="text-sm text-white/50">EUR₿</span>
-                <span class="text-2xl font-semibold">12%</span>
-                <span class="h-1 rounded-full bg-gradient-to-r from-[#3CFF6E] to-[#2AF7FF]"></span>
+              <div class="grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-sm text-white/60">Gold</span>
+                <div class="h-2 rounded-full bg-white/10">
+                  <div class="h-2 w-[48%] rounded-full bg-gradient-to-r from-primary via-[#5E7BFF] to-[#8E5BFF]"></div>
+                </div>
+                <span class="text-lg font-semibold">18%</span>
               </div>
-              <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                <span class="text-sm text-white/50">Gold</span>
-                <span class="text-2xl font-semibold">18%</span>
-                <span class="h-1 rounded-full bg-gradient-to-r from-[#22B5FF] to-[#805BFF]"></span>
+              <div class="grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-sm text-white/60">EUR</span>
+                <div class="h-2 rounded-full bg-white/10">
+                  <div class="h-2 w-[34%] rounded-full bg-gradient-to-r from-[#8E5BFF] via-danger to-warning"></div>
+                </div>
+                <span class="text-lg font-semibold">14%</span>
               </div>
-              <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                <span class="text-sm text-white/50">EUR</span>
-                <span class="text-2xl font-semibold">9%</span>
-                <span class="h-1 rounded-full bg-gradient-to-r from-[#805BFF] to-[#FF4F6D]"></span>
-              </div>
-              <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                <span class="text-sm text-white/50">USD</span>
-                <span class="text-2xl font-semibold">16%</span>
-                <span class="h-1 rounded-full bg-gradient-to-r from-[#FF4F6D] to-[#FF9F4D]"></span>
-              </div>
-              <div class="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-center">
-                <span class="text-sm text-white/50">TSLA</span>
-                <span class="text-2xl font-semibold">10%</span>
-                <span class="h-1 rounded-full bg-gradient-to-r from-[#FF9F4D] to-[#2AF7FF]"></span>
+              <div class="grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-sm text-white/60">TSLA</span>
+                <div class="h-2 rounded-full bg-white/10">
+                  <div class="h-2 w-[28%] rounded-full bg-gradient-to-r from-warning to-primary"></div>
+                </div>
+                <span class="text-lg font-semibold">10%</span>
               </div>
             </div>
           </section>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
             <div class="flex flex-wrap items-center gap-4">
-              <h3 class="text-lg font-semibold">Open Signals</h3>
-              <div class="flex gap-4 text-sm text-white/50">
+              <h3 class="text-lg font-semibold">Offene Signale</h3>
+              <div class="flex flex-wrap gap-4 text-sm text-white/50">
                 <span>Limits 1.2%</span>
                 <span>Max Drawdown € 10,5k</span>
                 <span>Daily Loss € 4,5k</span>
               </div>
-              <button class="ml-auto rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Logs</button>
+              <a href="automation.html" class="ml-auto rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">Regeln anpassen</a>
             </div>
             <div class="mt-6 space-y-4">
               <article class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div class="flex items-center justify-between text-sm text-white/60">
+                <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-white/60">
                   <span class="font-semibold text-white">Premium Forex Signals</span>
                   <span>€ 240</span>
                 </div>
-                <div class="mt-3 grid grid-cols-5 items-center gap-3 text-xs text-white/50">
+                <div class="mt-4 grid grid-cols-5 gap-3 text-xs text-white/50">
                   <div>
                     <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Risk</p>
                     <p class="text-sm text-safe">0.3%</p>
@@ -159,11 +200,11 @@
               </article>
 
               <article class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div class="flex items-center justify-between text-sm text-white/60">
+                <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-white/60">
                   <span class="font-semibold text-white">Gold Trading VIP</span>
                   <span>€ 1,3k</span>
                 </div>
-                <div class="mt-3 grid grid-cols-5 items-center gap-3 text-xs text-white/50">
+                <div class="mt-4 grid grid-cols-5 gap-3 text-xs text-white/50">
                   <div>
                     <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Risk</p>
                     <p class="text-sm text-danger">0.9%</p>
@@ -188,40 +229,11 @@
               </article>
 
               <article class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div class="flex items-center justify-between text-sm text-white/60">
-                  <span class="font-semibold text-white">Commodities Zone</span>
-                  <span>€ 920</span>
-                </div>
-                <div class="mt-3 grid grid-cols-5 items-center gap-3 text-xs text-white/50">
-                  <div>
-                    <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Risk</p>
-                    <p class="text-sm text-[#FF9F4D]">0.6%</p>
-                  </div>
-                  <div>
-                    <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Heatmap</p>
-                    <p class="text-sm">Orange</p>
-                  </div>
-                  <div>
-                    <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Latency</p>
-                    <p class="text-sm">52 ms</p>
-                  </div>
-                  <div>
-                    <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Hedging</p>
-                    <p class="text-sm">Aktiv</p>
-                  </div>
-                  <div>
-                    <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Leverage</p>
-                    <p class="text-sm">× 7</p>
-                  </div>
-                </div>
-              </article>
-
-              <article class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div class="flex items-center justify-between text-sm text-white/60">
+                <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-white/60">
                   <span class="font-semibold text-white">Crypto Signals Pro</span>
                   <span>€ 540</span>
                 </div>
-                <div class="mt-3 grid grid-cols-5 items-center gap-3 text-xs text-white/50">
+                <div class="mt-4 grid grid-cols-5 gap-3 text-xs text-white/50">
                   <div>
                     <p class="text-[11px] uppercase tracking-[0.2em] text-white/40">Risk</p>
                     <p class="text-sm text-safe">0.2%</p>
@@ -245,65 +257,90 @@
                 </div>
               </article>
             </div>
+          </section>
 
-            <footer class="mt-6 flex flex-col gap-3 border-t border-white/10 pt-4 text-sm text-white/50 sm:flex-row sm:items-center sm:justify-between">
-              <span>2 Compliance Alerts</span>
-              <span>Latency to Broker: 37 ms</span>
-            </footer>
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <header class="flex items-center justify-between">
+              <h3 class="text-lg font-semibold">Aktivität &amp; Compliance</h3>
+              <span class="text-xs uppercase tracking-[0.3em] text-white/50">Letzte 24h</span>
+            </header>
+            <div class="mt-6 space-y-4 text-sm text-white/60">
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="mt-1 text-lg">✅</span>
+                <div>
+                  <p class="font-medium text-white">Audit Log exportiert</p>
+                  <p class="text-white/60">Automatischer Upload ins sichere Archiv erfolgreich.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="mt-1 text-lg">⚠️</span>
+                <div>
+                  <p class="font-medium text-white">2 ungeprüfte Alerts</p>
+                  <p class="text-white/60">Bitte bestätige den Finanzstatus der US Futures Signale bis 18:00 Uhr.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="mt-1 text-lg">🛠️</span>
+                <div>
+                  <p class="font-medium text-white">Automation angepasst</p>
+                  <p class="text-white/60">Rule 4 wurde auf Backup-Broker verschoben.</p>
+                </div>
+              </div>
+            </div>
           </section>
         </section>
 
         <aside class="space-y-8">
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6 text-center shadow-[0_25px_80px_-60px_rgba(34,181,255,0.8)]">
-            <p class="text-sm uppercase tracking-[0.3em] text-white/60">Open Signals</p>
-            <div class="mt-4 flex flex-col items-center justify-center gap-6">
-              <div class="relative flex h-40 w-40 items-center justify-center">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 text-center shadow-glass backdrop-blur-2xl">
+            <p class="text-sm uppercase tracking-[0.3em] text-white/60">Live Auslastung</p>
+            <div class="mt-6 flex flex-col items-center gap-6">
+              <div class="relative flex h-48 w-48 items-center justify-center">
                 <div class="absolute inset-4 rounded-full border-2 border-dashed border-white/10"></div>
-                <div class="absolute inset-0 rounded-full bg-gradient-to-br from-[#2AF7FF]/30 to-[#3CFF6E]/10 blur-xl"></div>
-                <div class="relative flex h-full w-full items-center justify-center rounded-full border border-white/10 bg-[#05010F]"></div>
-                <div class="absolute flex h-24 w-24 flex-col items-center justify-center rounded-full bg-[#05010F] text-center">
-                  <span class="text-3xl font-semibold text-[#2AF7FF]">1.2%</span>
-                  <span class="text-xs uppercase tracking-[0.2em] text-white/50">Auslastung</span>
+                <div class="absolute inset-0 rounded-full bg-gradient-to-br from-primary/25 to-accent/15 blur-xl"></div>
+                <div class="relative flex h-full w-full items-center justify-center rounded-full border border-white/10 bg-[#030011]/80"></div>
+                <div class="absolute flex h-28 w-28 flex-col items-center justify-center rounded-full bg-[#030011] text-center">
+                  <span class="text-4xl font-semibold text-primary">1.2%</span>
+                  <span class="text-xs uppercase tracking-[0.25em] text-white/50">Risk Util.</span>
                 </div>
               </div>
               <div class="grid w-full grid-cols-3 gap-3 text-sm">
                 <div class="rounded-2xl border border-white/10 bg-white/5 p-3">
-                  <p class="text-xs uppercase tracking-[0.2em] text-white/50">Aktiv</p>
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Aktiv</p>
                   <p class="mt-1 text-lg font-semibold">12</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 bg-white/5 p-3">
-                  <p class="text-xs uppercase tracking-[0.2em] text-white/50">Max DD</p>
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Max DD</p>
                   <p class="mt-1 text-lg font-semibold">€ 10,5k</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 bg-white/5 p-3">
-                  <p class="text-xs uppercase tracking-[0.2em] text-white/50">Day Loss</p>
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Day Loss</p>
                   <p class="mt-1 text-lg font-semibold">€ 4,5k</p>
                 </div>
               </div>
             </div>
           </section>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
             <h3 class="text-lg font-semibold">Session Limits</h3>
-            <p class="mt-2 text-sm text-white/60">Setze präventive Limits für automatische Notabschaltungen, sobald dein Verlust oder die Latenz zu groß werden.</p>
+            <p class="mt-2 text-sm text-white/60">Definiere präventive Notabschaltungen für Verlust, Latenz und Fehlermeldungen.</p>
             <div class="mt-6 space-y-4">
-              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                 <div>
-                  <p class="text-xs uppercase tracking-[0.2em] text-white/50">Max Drawdown</p>
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Max Drawdown</p>
                   <p class="mt-1 text-lg font-semibold">€ 12,5k</p>
                 </div>
-                <button class="rounded-xl border border-white/10 bg-gradient-to-r from-[#2AF7FF] to-[#3CFF6E] px-4 py-2 text-xs font-semibold text-[#021222]">Anpassen</button>
+                <a href="automation.html" class="rounded-xl border border-white/10 bg-gradient-to-r from-primary to-accent px-4 py-2 text-xs font-semibold text-[#021222]">Anpassen</a>
               </div>
-              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                 <div>
-                  <p class="text-xs uppercase tracking-[0.2em] text-white/50">Daily Loss Limit</p>
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Daily Loss Limit</p>
                   <p class="mt-1 text-lg font-semibold">€ 6,0k</p>
                 </div>
                 <button class="rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold text-white/70">Editieren</button>
               </div>
-              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                 <div>
-                  <p class="text-xs uppercase tracking-[0.2em] text-white/50">Max Latency</p>
+                  <p class="text-xs uppercase tracking-[0.25em] text-white/50">Max Latency</p>
                   <p class="mt-1 text-lg font-semibold">75 ms</p>
                 </div>
                 <button class="rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold text-white/70">Editieren</button>
@@ -311,21 +348,40 @@
             </div>
           </section>
 
-          <section class="rounded-3xl border border-white/10 bg-white/5/10 bg-clip-padding p-6">
-            <h3 class="text-lg font-semibold">Compliance &amp; Security</h3>
-            <div class="mt-4 space-y-4 text-sm text-white/60">
-              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
-                <span class="mt-1 text-xl">✅</span>
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Automation Shortcuts</h3>
+            <div class="mt-5 space-y-3 text-sm text-white/60">
+              <a href="automation.html" class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 transition hover:bg-white/10">
+                <span>Gold Hedging Preset</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Aktiv</span>
+              </a>
+              <a href="automation.html" class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 transition hover:bg-white/10">
+                <span>Latency Guard</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Standby</span>
+              </a>
+              <a href="automation.html" class="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 transition hover:bg-white/10">
+                <span>Volume Surge Alert</span>
+                <span class="text-xs uppercase tracking-[0.25em] text-white/40">Off</span>
+              </a>
+            </div>
+            <button class="mt-5 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-xs uppercase tracking-[0.25em] text-white/70">Neue Regel erstellen</button>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Compliance Status</h3>
+            <div class="mt-5 space-y-3 text-sm text-white/60">
+              <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">🕒</span>
                 <div>
-                  <p class="font-medium text-white">Protokoll automatisch exportiert</p>
-                  <p class="mt-1 text-white/60">Audit-Log der letzten 24h wurde an deinen sicheren Speicher gesendet.</p>
+                  <p class="font-medium text-white">MiFID II Report</p>
+                  <p class="text-white/60">Automatischer Upload geplant um 18:30 Uhr.</p>
                 </div>
               </div>
-              <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
-                <span class="mt-1 text-xl">⚠️</span>
+              <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span class="text-lg">🛡️</span>
                 <div>
-                  <p class="font-medium text-white">2 ungeprüfte Alerts</p>
-                  <p class="mt-1 text-white/60">Bitte bestätige den Finanzstatus der US Futures Signale bis 18:00 Uhr.</p>
+                  <p class="font-medium text-white">Penetration Test</p>
+                  <p class="text-white/60">Letzter Test vor 6 Tagen · Keine Findings.</p>
                 </div>
               </div>
             </div>
@@ -335,9 +391,11 @@
 
       <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
         <span>© 2024 CannabisApp · Trading Automation Suite</span>
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="start.html">Onboarding</a>
-          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="homescreen.html">Classic UI</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="automation.html">Automationen</a>
         </div>
       </footer>
     </div>

--- a/performance.html
+++ b/performance.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Trading Bot Performance · CannabisApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Outfit', 'sans-serif']
+          },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            danger: '#FF4F6D',
+            surface: 'rgba(5, 18, 40, 0.8)'
+          },
+          boxShadow: {
+            glass: '0 45px 140px -60px rgba(42, 247, 255, 0.55)'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="min-h-screen bg-[#030015] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#020012] via-[#06092D] to-[#001B34]"></div>
+    <div class="absolute -top-40 -left-28 h-96 w-96 rounded-full bg-[#2C7DFF]/25 blur-3xl"></div>
+    <div class="absolute -bottom-36 -right-24 h-96 w-96 rounded-full bg-[#25F4C7]/20 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.12),_transparent_60%)]"></div>
+
+    <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10">
+      <header class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.55em] text-white/50">Trading Bot Performance</p>
+          <h1 class="mt-2 text-4xl font-semibold">Performance Dashboard</h1>
+          <p class="mt-3 max-w-2xl text-sm text-white/60">Überprüfe Rendite, Risikokennzahlen und die Performance einzelner Sessions. Visualisiere Equity-Entwicklung und Profite in Echtzeit.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+          <a href="index.html" class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2 transition hover:bg-white/15">Zurück zum Center</a>
+          <button class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2">Jan 1 – Apr 25 · 📅</button>
+          <button class="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-gradient-to-r from-primary to-accent px-4 py-2 text-[#021222] font-semibold">Exportieren</button>
+        </div>
+      </header>
+
+      <main class="mt-10 grid flex-1 gap-8 xl:grid-cols-[1.55fr_1fr]">
+        <section class="space-y-8">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 shadow-glass backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-6">
+              <div>
+                <h2 class="text-lg font-semibold">Equity Curve</h2>
+                <p class="text-sm text-white/50">Bruttorendite inklusive Hedging</p>
+              </div>
+              <span class="ml-auto inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.3em] text-white/60">Live <span class="inline-flex h-2 w-2 rounded-full bg-primary"></span></span>
+            </div>
+            <div class="relative mt-6 h-80 overflow-hidden rounded-[28px] border border-white/5 bg-gradient-to-b from-white/10 to-transparent">
+              <div class="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(60,255,110,0.18),_transparent_60%)]"></div>
+              <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[length:80px_1px]"></div>
+              <div class="absolute inset-0 bg-[linear-gradient(to_top,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:1px_60px]"></div>
+              <svg viewBox="0 0 800 320" class="relative h-full w-full">
+                <defs>
+                  <linearGradient id="equityLine" x1="0%" x2="100%" y1="0%" y2="0%">
+                    <stop offset="0%" stop-color="#2AF7FF" />
+                    <stop offset="100%" stop-color="#3CFF6E" />
+                  </linearGradient>
+                </defs>
+                <path d="M0 260 Q120 210 180 230 T320 170 T460 190 T640 110 T800 70" stroke="url(#equityLine)" stroke-width="6" fill="none" stroke-linecap="round"></path>
+                <path d="M0 320 L0 260 Q120 210 180 230 T320 170 T460 190 T640 110 T800 70 L800 320 Z" fill="url(#equityLine)" opacity="0.2"></path>
+              </svg>
+              <div class="absolute bottom-4 right-4 rounded-2xl border border-white/10 bg-black/40 px-3 py-2 text-xs text-white/70 backdrop-blur">Letztes Update: 08:45 Uhr</div>
+            </div>
+            <div class="mt-6 grid gap-4 md:grid-cols-4">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Sharpe</p>
+                <p class="mt-2 text-3xl font-semibold">1,45</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Sortino</p>
+                <p class="mt-2 text-3xl font-semibold">2,30</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Max Drawdown</p>
+                <p class="mt-2 text-3xl font-semibold text-danger">-13,7%</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Win Rate</p>
+                <p class="mt-2 text-3xl font-semibold text-accent">67,5%</p>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
+              <h2 class="text-lg font-semibold">Monthly Performance</h2>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/50">YTD</span>
+              <button class="ml-auto rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">CSV Export</button>
+            </div>
+            <div class="mt-6 grid gap-3 md:grid-cols-3">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Januar</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">+ 1.230 €</p>
+                <p class="mt-3 text-xs text-white/50">8 Gewinner · 3 Verlierer</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Februar</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">+ 980 €</p>
+                <p class="mt-3 text-xs text-white/50">6 Gewinner · 2 Verlierer</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">März</p>
+                <p class="mt-2 text-2xl font-semibold text-danger">- 420 €</p>
+                <p class="mt-3 text-xs text-white/50">3 Gewinner · 5 Verlierer</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">April</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">+ 1.560 €</p>
+                <p class="mt-3 text-xs text-white/50">7 Gewinner · 2 Verlierer</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Mai</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">+ 640 €</p>
+                <p class="mt-3 text-xs text-white/50">4 Gewinner · 2 Verlierer</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.25em] text-white/50">Juni</p>
+                <p class="mt-2 text-2xl font-semibold text-accent">+ 1.020 €</p>
+                <p class="mt-3 text-xs text-white/50">5 Gewinner · 1 Verlierer</p>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <div class="flex flex-wrap items-center gap-4">
+              <h2 class="text-lg font-semibold">Signale &amp; Gewinnbeiträge</h2>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/50">Top 5</span>
+            </div>
+            <div class="mt-6 space-y-4">
+              <div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/20 text-primary">1</span>
+                <div>
+                  <p class="font-semibold text-white">Gold Trading VIP</p>
+                  <p class="text-xs text-white/50">Trendfolge · 4h</p>
+                </div>
+                <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/50">Win 68%</span>
+                <span class="text-lg font-semibold text-accent">+ 1.820 €</span>
+              </div>
+              <div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/15 text-primary">2</span>
+                <div>
+                  <p class="font-semibold text-white">Premium Forex Signals</p>
+                  <p class="text-xs text-white/50">Scalping · 1h</p>
+                </div>
+                <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/50">Win 61%</span>
+                <span class="text-lg font-semibold text-accent">+ 1.120 €</span>
+              </div>
+              <div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">3</span>
+                <div>
+                  <p class="font-semibold text-white">Crypto Signals Pro</p>
+                  <p class="text-xs text-white/50">Momentum · 2h</p>
+                </div>
+                <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/50">Win 72%</span>
+                <span class="text-lg font-semibold text-accent">+ 840 €</span>
+              </div>
+              <div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">4</span>
+                <div>
+                  <p class="font-semibold text-white">Commodities Zone</p>
+                  <p class="text-xs text-white/50">Breakout · 30m</p>
+                </div>
+                <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/50">Win 54%</span>
+                <span class="text-lg font-semibold text-warning">+ 420 €</span>
+              </div>
+              <div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">5</span>
+                <div>
+                  <p class="font-semibold text-white">Asia Session Guard</p>
+                  <p class="text-xs text-white/50">Mean Reversion · 45m</p>
+                </div>
+                <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/50">Win 59%</span>
+                <span class="text-lg font-semibold text-accent">+ 360 €</span>
+              </div>
+            </div>
+          </section>
+        </section>
+
+        <aside class="space-y-8">
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Profit Überblick</h3>
+            <p class="mt-2 text-3xl font-semibold text-accent">+ 4.453 €</p>
+            <p class="text-sm text-white/60">Bruttorendite seit Jahresbeginn</p>
+            <div class="mt-6 space-y-3 text-sm text-white/60">
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Nettoergebnis</span>
+                <span class="text-lg font-semibold text-accent">+ 3.870 €</span>
+              </div>
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Fees &amp; Slippage</span>
+                <span class="text-lg font-semibold text-danger">- 420 €</span>
+              </div>
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Hedging Cost</span>
+                <span class="text-lg font-semibold text-warning">- 163 €</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Wochen-Heatmap</h3>
+            <div class="mt-6 grid grid-cols-7 gap-2 text-center text-[11px] text-white/40">
+              <span>M</span><span>D</span><span>M</span><span>D</span><span>F</span><span>S</span><span>S</span>
+            </div>
+            <div class="mt-3 grid grid-cols-7 gap-2">
+              <div class="h-10 rounded-lg bg-primary/5"></div>
+              <div class="h-10 rounded-lg bg-primary/10"></div>
+              <div class="h-10 rounded-lg bg-primary/30"></div>
+              <div class="h-10 rounded-lg bg-accent/50"></div>
+              <div class="h-10 rounded-lg bg-accent/80"></div>
+              <div class="h-10 rounded-lg bg-accent/50"></div>
+              <div class="h-10 rounded-lg bg-primary/20"></div>
+              <div class="h-10 rounded-lg bg-primary/15"></div>
+              <div class="h-10 rounded-lg bg-primary/5"></div>
+              <div class="h-10 rounded-lg bg-accent/30"></div>
+              <div class="h-10 rounded-lg bg-accent/60"></div>
+              <div class="h-10 rounded-lg bg-accent/20"></div>
+              <div class="h-10 rounded-lg bg-primary/10"></div>
+              <div class="h-10 rounded-lg bg-primary/5"></div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Profit Verteilung</h3>
+            <div class="mt-6 space-y-2">
+              <div class="flex items-end gap-2">
+                <div class="flex-1 rounded-t-lg bg-primary/30" style="height: 60px"></div>
+                <div class="flex-1 rounded-t-lg bg-primary/40" style="height: 120px"></div>
+                <div class="flex-1 rounded-t-lg bg-accent/70" style="height: 180px"></div>
+                <div class="flex-1 rounded-t-lg bg-primary/40" style="height: 100px"></div>
+                <div class="flex-1 rounded-t-lg bg-primary/20" style="height: 70px"></div>
+              </div>
+              <div class="flex justify-between text-xs text-white/40">
+                <span>-800</span>
+                <span>-200</span>
+                <span>0</span>
+                <span>400</span>
+                <span>800</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-[34px] border border-white/10 bg-surface p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold">Drawdown Verlauf</h3>
+            <div class="mt-6 space-y-3 text-sm text-white/60">
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Ø Drawdown</span>
+                <span class="text-lg font-semibold text-white/80">-4,7%</span>
+              </div>
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Tiefster Punkt</span>
+                <span class="text-lg font-semibold text-danger">-13,7%</span>
+              </div>
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Recovery Zeit</span>
+                <span class="text-lg font-semibold text-accent">8 Tage</span>
+              </div>
+            </div>
+          </section>
+        </aside>
+      </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="automation.html">Automationen</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/start.html
+++ b/start.html
@@ -15,62 +15,159 @@
           fontFamily: {
             sans: ['Outfit', 'sans-serif']
           },
+          colors: {
+            primary: '#2AF7FF',
+            accent: '#3CFF6E',
+            surface: 'rgba(6, 17, 41, 0.72)'
+          },
           boxShadow: {
-            onboarding: '0 40px 80px -40px rgba(28, 225, 255, 0.45)'
+            glow: '0 45px 140px -60px rgba(42, 247, 255, 0.55)'
           }
         }
       }
     }
   </script>
 </head>
-<body class="min-h-screen bg-[#050111] text-white font-sans">
-  <div class="relative overflow-hidden min-h-screen flex items-center justify-center px-6 py-12">
-    <div class="absolute inset-0 bg-gradient-to-br from-[#050111] via-[#0B0A28] to-[#061835]"></div>
-    <div class="absolute -top-20 -left-24 h-72 w-72 rounded-full bg-[#1C69FF]/20 blur-3xl"></div>
-    <div class="absolute -bottom-24 -right-16 h-72 w-72 rounded-full bg-[#27EFB4]/10 blur-3xl"></div>
+<body class="min-h-screen bg-[#040012] font-sans text-white">
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-[#040012] via-[#060B26] to-[#041B36]"></div>
+    <div class="absolute -top-40 -left-28 h-96 w-96 rounded-full bg-[#2C7DFF]/25 blur-3xl"></div>
+    <div class="absolute -bottom-32 -right-24 h-96 w-96 rounded-full bg-[#2AF7FF]/20 blur-3xl"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(42,247,255,0.12),_transparent_55%)]"></div>
 
-    <div class="relative w-full max-w-sm">
-      <header class="text-center uppercase tracking-[0.3em] text-xs text-white/70">
-        <h1 class="text-3xl font-semibold tracking-[0.5em]">Onboarding</h1>
-        <div class="mt-8 flex items-center justify-between">
-          <div class="flex-1 flex justify-between px-1">
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-[#32E4FF] to-[#2AD8B6] text-sm font-semibold text-[#050111] shadow-onboarding">1</span>
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-white/5 text-sm font-semibold">2</span>
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">3</span>
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">4</span>
-          </div>
+    <div class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-12">
+      <header class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-[0.55em] text-white/50">Risk Automation Suite</p>
+          <h1 class="mt-2 text-4xl font-semibold tracking-[0.18em] text-white">Onboarding</h1>
+          <p class="mt-3 max-w-xl text-sm text-white/60">Führe deinen Trading-Bot in vier einfachen Schritten live: Verbinde Telegram, bestätige deine Kanäle, wähle die Sicherheitsstufe und starte anschließend die Automatisierung.</p>
+        </div>
+        <div class="flex items-center gap-3 text-sm text-white/60">
+          <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur">💡 <span>Guided Setup aktiv</span></span>
+          <a href="index.html" class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-white/70 transition hover:bg-white/10">Zurück zum Center</a>
         </div>
       </header>
 
-      <main class="mt-10 rounded-3xl border border-white/5 bg-white/5/10 bg-clip-padding backdrop-blur-xl p-8 shadow-[0_30px_60px_-40px_rgba(0,0,0,0.8)]">
-        <div class="flex items-center gap-3 text-[#33C7FF]">
-          <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#0E1B3B] text-xl">📨</span>
-          <div>
-            <p class="text-sm uppercase tracking-[0.3em] text-white/60">Connect</p>
-            <h2 class="text-xl font-semibold">Telegram</h2>
+      <main class="mt-12 grid flex-1 gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+        <section class="rounded-[32px] border border-white/10 bg-surface/80 p-8 shadow-glow backdrop-blur-2xl">
+          <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p class="text-[11px] uppercase tracking-[0.4em] text-white/50">Schritt 1</p>
+              <h2 class="mt-1 text-2xl font-semibold text-primary">Telegram verbinden</h2>
+            </div>
+            <div class="hidden gap-3 text-xs uppercase tracking-[0.3em] text-white/50 sm:flex">
+              <span class="rounded-full border border-white/15 px-3 py-1 text-white/70">Verifizieren</span>
+              <span class="rounded-full border border-white/10 px-3 py-1">Security Check</span>
+            </div>
           </div>
-        </div>
 
-        <form class="mt-8 space-y-5">
-          <div>
-            <label for="api-id" class="mb-2 block text-xs uppercase tracking-[0.3em] text-white/50">API ID</label>
-            <input id="api-id" type="text" value="1234567" class="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder-white/30 focus:border-[#33C7FF] focus:outline-none focus:ring-2 focus:ring-[#33C7FF]/40">
+          <ol class="mt-8 grid gap-4 md:grid-cols-4">
+            <li class="flex flex-col items-center gap-2 rounded-2xl border border-primary/30 bg-primary/15 px-4 py-3 text-center shadow-[0_10px_40px_-35px_rgba(42,247,255,0.9)]">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-primary to-accent text-sm font-semibold text-[#031326]">1</span>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/70">Connect</span>
+            </li>
+            <li class="flex flex-col items-center gap-2 rounded-2xl border border-white/15 bg-white/5 px-4 py-3 text-center">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/20 text-sm font-semibold text-white/70">2</span>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/50">Channels</span>
+            </li>
+            <li class="flex flex-col items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-sm font-semibold text-white/40">3</span>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/40">Risk</span>
+            </li>
+            <li class="flex flex-col items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center">
+              <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-sm font-semibold text-white/40">4</span>
+              <span class="text-xs uppercase tracking-[0.25em] text-white/40">Start</span>
+            </li>
+          </ol>
+
+          <form class="mt-10 grid gap-6 md:grid-cols-2">
+            <label class="flex flex-col gap-2">
+              <span class="text-[11px] uppercase tracking-[0.35em] text-white/55">API ID</span>
+              <div class="relative">
+                <input type="text" value="1234567" class="w-full rounded-2xl border border-white/10 bg-[#071027]/70 px-4 py-3 text-base text-white placeholder-white/30 shadow-[0_18px_45px_-35px_rgba(0,0,0,0.8)] focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40">
+                <span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-xs uppercase tracking-[0.2em] text-white/30">ID</span>
+              </div>
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="text-[11px] uppercase tracking-[0.35em] text-white/55">API Hash</span>
+              <div class="relative">
+                <input type="password" value="••••••••••" class="w-full rounded-2xl border border-white/10 bg-[#071027]/70 px-4 py-3 text-base text-white placeholder-white/30 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40">
+                <span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-xs uppercase tracking-[0.2em] text-white/30">SEC</span>
+              </div>
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="text-[11px] uppercase tracking-[0.35em] text-white/55">Telefon-Code</span>
+              <input type="text" value="+49" class="w-full rounded-2xl border border-white/10 bg-[#071027]/70 px-4 py-3 text-base text-white placeholder-white/30 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40">
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="text-[11px] uppercase tracking-[0.35em] text-white/55">Bot Alias</span>
+              <input type="text" value="Atlas Risk Guard" class="w-full rounded-2xl border border-white/10 bg-[#071027]/70 px-4 py-3 text-base text-white placeholder-white/30 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40">
+            </label>
+            <div class="md:col-span-2 flex flex-col gap-4 rounded-2xl border border-white/10 bg-[#060F26]/80 px-5 py-4">
+              <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/10 text-lg">🔒</span>
+                  <div>
+                    <p class="text-sm font-medium text-white">Zwei-Faktor-Authentifizierung</p>
+                    <p class="text-xs uppercase tracking-[0.25em] text-white/40">Empfohlen</p>
+                  </div>
+                </div>
+                <button type="button" class="rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.25em] text-white/60">Aktivieren</button>
+              </div>
+              <p class="text-xs text-white/50">Verbinde zusätzlich die verifizierte Telefonnummer für kritische Aktionen wie Not-Stopp oder Limit-Änderungen.</p>
+            </div>
+          </form>
+
+          <div class="mt-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div class="flex flex-col gap-2 text-sm text-white/60">
+              <span class="inline-flex items-center gap-2 text-white/70"><span class="inline-flex h-2 w-2 rounded-full bg-accent"></span> Sicherer Kanal aktiv</span>
+              <span>Letzte Verbindung <strong class="font-medium text-white">vor 12 Minuten</strong></span>
+            </div>
+            <button class="inline-flex items-center justify-center gap-3 rounded-[22px] bg-gradient-to-r from-primary via-[#30F2C6] to-accent px-8 py-4 text-lg font-semibold text-[#04111F] shadow-[0_28px_95px_-50px_rgba(60,255,110,0.85)] transition-transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/60 focus:ring-offset-[#040012]">
+              Weiter zu Kanälen
+              <span class="text-xl">→</span>
+            </button>
           </div>
-          <div>
-            <label for="api-hash" class="mb-2 block text-xs uppercase tracking-[0.3em] text-white/50">API Hash</label>
-            <input id="api-hash" type="password" value="••••••••••" class="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder-white/30 focus:border-[#33C7FF] focus:outline-none focus:ring-2 focus:ring-[#33C7FF]/40">
-          </div>
-        </form>
+        </section>
 
-        <ol class="mt-8 space-y-2 text-sm text-white/70">
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">1.</span> Verbinde deinen Telegram-Account</li>
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">2.</span> Wähle deine Chats aus</li>
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">3.</span> Lege das Risikoniveau fest</li>
-          <li class="flex items-center gap-2"><span class="text-[#32E4FF]">4.</span> Starte den Bot</li>
-        </ol>
+        <aside class="space-y-6">
+          <section class="rounded-[32px] border border-white/10 bg-surface/80 p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold text-white">Live-Überblick</h3>
+            <div class="mt-4 space-y-4 text-sm text-white/60">
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Aktive Bots</span>
+                <span class="text-lg font-semibold text-primary">12</span>
+              </div>
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Risk Preset</span>
+                <span class="text-lg font-semibold text-accent">Balanced</span>
+              </div>
+              <div class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <span>Letzte Änderung</span>
+                <span class="text-lg font-semibold text-white/80">08:42</span>
+              </div>
+            </div>
+          </section>
 
-        <button class="mt-10 w-full rounded-2xl bg-gradient-to-r from-[#2AF7FF] via-[#2EF0B5] to-[#3CFF6E] px-6 py-4 text-lg font-semibold text-[#050111] shadow-[0_20px_60px_-30px_rgba(46,240,181,0.8)] transition-transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#2EF0B5] focus:ring-offset-[#050111]">Start Bot</button>
+          <section class="rounded-[32px] border border-white/10 bg-surface/80 p-6 backdrop-blur-2xl">
+            <h3 class="text-lg font-semibold text-white">Checkliste</h3>
+            <ul class="mt-4 space-y-3 text-sm text-white/65">
+              <li class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><span class="text-xl">✅</span><span>API Schlüssel aus BotFather kopieren</span></li>
+              <li class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><span class="text-xl">⬜️</span><span>Signals Premium &amp; Gold VIP bestätigen</span></li>
+              <li class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><span class="text-xl">⬜️</span><span>Notabschaltung via SMS testen</span></li>
+            </ul>
+          </section>
+        </aside>
       </main>
+
+      <footer class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 py-6 text-sm text-white/40 sm:flex-row">
+        <span>© 2024 CannabisApp · Trading Automation Suite</span>
+        <div class="flex flex-wrap items-center gap-3">
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="index.html">Risk Center</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="performance.html">Performance</a>
+          <a class="rounded-xl border border-white/10 bg-white/5 px-3 py-1.5" href="chat-stats.html">Chat Stats</a>
+        </div>
+      </footer>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- restyled the onboarding, risk center, automation, performance, and chat statistics screens with layered neon-glass layouts that mirror the provided screenshots
- rebuilt content blocks with detailed metrics, timelines, gauges, and shortcut panels so every screen reflects the referenced sections one-to-one

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d01948ca9c83328ff2a9ece4ec7139